### PR TITLE
Complete with  test _unittest_raft_leader_changes()

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ This feature is significant because it enables Cyphal to serve as a communicatio
         - [ ] some warning need to be fixed here:
           - [ ] _unittest_raft_node_term_timeout
           - [ ] _unittest_raft_node_start_election
-      - [ ] `log_replication.py`
+      - [x] `log_replication.py`
         - [x] `_unittest_raft_log_replication`
-        - [ ] `_unittest_raft_leader_changes`
+        - [x] `_unittest_raft_leader_changes`
       - [ ] `leader_commit` needs to integrated/tested
     - [ ] Test using orchestration so there's 3 nodes running simultanously
       - [ ] use yakut to send AppendEntries requests

--- a/cyraft/election_watchdog.py
+++ b/cyraft/election_watchdog.py
@@ -18,7 +18,9 @@ class ElectionWatchdog:
         loop = asyncio.get_event_loop()
         self._next_election_timeout = loop.time() + self.election_timeout
         self._election_timer.cancel()
-        self._election_timer = loop.call_at(self._next_election_timeout, self.on_election_timeout)
+        self._election_timer = loop.call_at(
+            self._next_election_timeout, self.on_election_timeout
+        )
 
     def on_election_timeout(self) -> None:
         _logger.debug("Election timeout reached!")
@@ -29,7 +31,9 @@ class ElectionWatchdog:
         _logger.debug("Starting election watchdog")
         loop = asyncio.get_event_loop()
         self._next_election_timeout = loop.time() + self.election_timeout
-        self._election_timer = loop.call_at(self._next_election_timeout, self.on_election_timeout)
+        self._election_timer = loop.call_at(
+            self._next_election_timeout, self.on_election_timeout
+        )
 
     def close(self) -> None:
         _logger.debug("Closing election watchdog")
@@ -43,11 +47,15 @@ async def _unittest_election_watchdog() -> None:
     watchdog_node = ElectionWatchdog()
     asyncio.create_task(watchdog_node.run())
 
-    await asyncio.sleep(ELECTION_TIMEOUT - 1)  # Election timeout should not be reached here
+    await asyncio.sleep(
+        ELECTION_TIMEOUT - 1
+    )  # Election timeout should not be reached here
 
     watchdog_node.reset_election_timeout()  # Reset election timeout
 
-    await asyncio.sleep(1)  # Election timeout should be reached here, but it should be reset above
+    await asyncio.sleep(
+        1
+    )  # Election timeout should be reached here, but it should be reset above
 
     _logger.debug("==== Election timeout should not be reached above this line ====")
     assert watchdog_node.election_timeout_reached is False

--- a/cyraft/election_watchdog.py
+++ b/cyraft/election_watchdog.py
@@ -18,9 +18,7 @@ class ElectionWatchdog:
         loop = asyncio.get_event_loop()
         self._next_election_timeout = loop.time() + self.election_timeout
         self._election_timer.cancel()
-        self._election_timer = loop.call_at(
-            self._next_election_timeout, self.on_election_timeout
-        )
+        self._election_timer = loop.call_at(self._next_election_timeout, self.on_election_timeout)
 
     def on_election_timeout(self) -> None:
         _logger.debug("Election timeout reached!")
@@ -31,9 +29,7 @@ class ElectionWatchdog:
         _logger.debug("Starting election watchdog")
         loop = asyncio.get_event_loop()
         self._next_election_timeout = loop.time() + self.election_timeout
-        self._election_timer = loop.call_at(
-            self._next_election_timeout, self.on_election_timeout
-        )
+        self._election_timer = loop.call_at(self._next_election_timeout, self.on_election_timeout)
 
     def close(self) -> None:
         _logger.debug("Closing election watchdog")
@@ -47,15 +43,11 @@ async def _unittest_election_watchdog() -> None:
     watchdog_node = ElectionWatchdog()
     asyncio.create_task(watchdog_node.run())
 
-    await asyncio.sleep(
-        ELECTION_TIMEOUT - 1
-    )  # Election timeout should not be reached here
+    await asyncio.sleep(ELECTION_TIMEOUT - 1)  # Election timeout should not be reached here
 
     watchdog_node.reset_election_timeout()  # Reset election timeout
 
-    await asyncio.sleep(
-        1
-    )  # Election timeout should be reached here, but it should be reset above
+    await asyncio.sleep(1)  # Election timeout should be reached here, but it should be reset above
 
     _logger.debug("==== Election timeout should not be reached above this line ====")
     assert watchdog_node.election_timeout_reached is False

--- a/cyraft/node.py
+++ b/cyraft/node.py
@@ -631,17 +631,6 @@ class RaftNode:
 
         if self._state == RaftState.FOLLOWER:
             # Cancel the term timeout (if it exists), and schedule a new election timeout.
-            for remote_node_index, remote_next_index in enumerate(self._next_index):
-                _logger.info(
-                    c["raft_logic"]
-                    + "Node ID: %d -- Value of next index = %d and value of remote next index = %s for node %s"
-                    + c["end_color"],
-                    self._node.id,
-                    self._commit_index,
-                    remote_next_index,
-                    self._cluster[remote_node_index],
-                )
-
             if hasattr(self, "_term_timer"):
                 self._term_timer.cancel()  # FOLLOWER should not have term timer
             self._reset_election_timeout()  # FOLLOWER should have election timer

--- a/cyraft/node.py
+++ b/cyraft/node.py
@@ -88,6 +88,8 @@ class RaftNode:
 
         ## Volatile state on leaders
         self._next_index: typing.List[int] = []  # index of the next log entry to send to that server
+
+
         # self._match_index: typing.List[int] = []  # index of highest log entry known to be replicated on server
 
         ########################################
@@ -367,15 +369,19 @@ class RaftNode:
                     self._node.id,
                 )
                 return sirius_cyber_corp.AppendEntries_1.Response(term=self._term, success=False)
-        except IndexError:
+        except IndexError as e:
             _logger.info(
-                c["append_entries"] + "Node ID: %d -- Append entries request denied (log mismatch 2)" + c["end_color"],
-                self._node.id,
-            )
+            c["append_entries"]
+            + "Node ID: %d -- Append entries request denied (log mismatch 2). IndexError: %s. "
+            + "prev_log_index: %d, log_length: %d"
+            + c["end_color"],
+            self._node.id,
+            str(e),
+            request.prev_log_index,
+            len(self._log))
             return sirius_cyber_corp.AppendEntries_1.Response(term=self._term, success=False)
 
         self._append_entries_processing(request)
-
         return sirius_cyber_corp.AppendEntries_1.Response(term=self._term, success=True)
 
     def _append_entries_processing(
@@ -448,7 +454,9 @@ class RaftNode:
 
         # Update current_term (if follower) (leaders will update their own term on timeout)
         if self._state == RaftState.FOLLOWER:
+            self._change_state(RaftState.FOLLOWER)  # this will reset the election timeout as well
             self._term = request.log_entry[0].term
+            
 
     async def _send_heartbeat(self, remote_node_index: int) -> None:
         """
@@ -623,17 +631,6 @@ class RaftNode:
 
         if self._state == RaftState.FOLLOWER:
             # Cancel the term timeout (if it exists), and schedule a new election timeout.
-            for remote_node_index, remote_next_index in enumerate(self._next_index):
-                _logger.info(
-                    c["raft_logic"]
-                    + "Node ID: %d -- Value of next index = %d and value of remote next index = %s for node %s"
-                    + c["end_color"],
-                    self._node.id,
-                    self._commit_index,
-                    remote_next_index,
-                    self._cluster[remote_node_index],
-                )
-
             if hasattr(self, "_term_timer"):
                 self._term_timer.cancel()  # FOLLOWER should not have term timer
             self._reset_election_timeout()  # FOLLOWER should have election timer
@@ -714,7 +711,7 @@ class RaftNode:
                 + "Node ID: %d -- Value of next index = %d and value of remote next index = %s for node %s"
                 + c["end_color"],
                 self._node.id,
-                self._commit_index,
+                self._commit_index + 1,
                 remote_next_index,
                 self._cluster[remote_node_index],
             )

--- a/cyraft/node.py
+++ b/cyraft/node.py
@@ -60,7 +60,9 @@ class RaftNode:
         self._term_timer: asyncio.TimerHandle
         self._next_term_timeout: float
 
-        self._election_timeout: float = 0.15 + 0.15 * os.urandom(1)[0] / 255.0  # random between 150 and 300 ms
+        self._election_timeout: float = (
+            0.15 + 0.15 * os.urandom(1)[0] / 255.0
+        )  # random between 150 and 300 ms
         self._term_timeout = TERM_TIMEOUT
         # assert (
         #     self._term_timeout < self._election_timeout / 2
@@ -87,8 +89,9 @@ class RaftNode:
         # self.last_applied: int = 0 # QUESTION: Is this even necessary? Do we have a "state machine"?
 
         ## Volatile state on leaders
-        self._next_index: typing.List[int] = []  # index of the next log entry to send to that server
-
+        self._next_index: typing.List[int] = (
+            []
+        )  # index of the next log entry to send to that server
 
         # self._match_index: typing.List[int] = []  # index of highest log entry known to be replicated on server
 
@@ -101,17 +104,19 @@ class RaftNode:
         self._node.heartbeat_publisher.vendor_specific_status_code = os.getpid() % 100
 
         # Create an RPC-server. (RequestVote)
-        self._node.get_server(sirius_cyber_corp.RequestVote_1, "request_vote").serve_in_background(
-            self._serve_request_vote
-        )
+        self._node.get_server(
+            sirius_cyber_corp.RequestVote_1, "request_vote"
+        ).serve_in_background(self._serve_request_vote)
 
         # Create an RPC-server. (AppendEntries)
-        self._node.get_server(sirius_cyber_corp.AppendEntries_1, "append_entries").serve_in_background(
-            self._serve_append_entries
-        )
+        self._node.get_server(
+            sirius_cyber_corp.AppendEntries_1, "append_entries"
+        ).serve_in_background(self._serve_append_entries)
 
         # Create an RPC-server. (ExecuteCommand)
-        self._node.get_server(uavcan.node.ExecuteCommand_1).serve_in_background(self._serve_execute_command)
+        self._node.get_server(uavcan.node.ExecuteCommand_1).serve_in_background(
+            self._serve_execute_command
+        )
 
         self._node.start()
 
@@ -146,9 +151,15 @@ class RaftNode:
 
         for node_id in remote_node_id:
             if node_id not in self._cluster and node_id != self._node.id:
-                _logger.info(c["raft_logic"] + f"Adding node {node_id} to cluster" + c["end_color"])
+                _logger.info(
+                    c["raft_logic"]
+                    + f"Adding node {node_id} to cluster"
+                    + c["end_color"]
+                )
                 self._cluster.append(node_id)
-                request_vote_client = self._node.make_client(sirius_cyber_corp.RequestVote_1, node_id, "request_vote")
+                request_vote_client = self._node.make_client(
+                    sirius_cyber_corp.RequestVote_1, node_id, "request_vote"
+                )
                 self._request_vote_clients.append(request_vote_client)
                 append_entries_client = self._node.make_client(
                     sirius_cyber_corp.AppendEntries_1, node_id, "append_entries"
@@ -169,7 +180,11 @@ class RaftNode:
         It also removes the corresponding clients.
         """
         if remote_node_id in self._cluster:
-            _logger.info(c["raft_logic"] + f"Removing node {remote_node_id} from cluster" + c["end_color"])
+            _logger.info(
+                c["raft_logic"]
+                + f"Removing node {remote_node_id} from cluster"
+                + c["end_color"]
+            )
             index = self._cluster.index(remote_node_id)
             self._cluster.pop(index)
             self._request_vote_clients.pop(index)
@@ -186,7 +201,9 @@ class RaftNode:
         This method receives the request vote request from the candidate and calls the implementation method.
         """
         _logger.info(
-            c["request_vote"] + "Node ID: %d -- Request vote request %s from node %d" + c["end_color"],
+            c["request_vote"]
+            + "Node ID: %d -- Request vote request %s from node %d"
+            + c["end_color"],
             self._node.id,
             request,
             metadata.client_node_id,
@@ -215,10 +232,11 @@ class RaftNode:
          3. Reset voted_for
         """
         if request.term > self._term:
-            self._change_state(RaftState.FOLLOWER) # Our term is stale, so we can't serve as leader 
+            self._change_state(
+                RaftState.FOLLOWER
+            )  # Our term is stale, so we can't serve as leader
             self._term = request.term
             self._voted_for = None
-
 
         if request.term < self._term:
             vote_granted = False
@@ -230,22 +248,28 @@ class RaftNode:
                 self._term,
             )
         else:
-            vote_granted = (self._voted_for is None or self._voted_for == client_node_id) and self._log[request.last_log_index].term == request.last_log_term
+            vote_granted = (
+                self._voted_for is None or self._voted_for == client_node_id
+            ) and self._log[request.last_log_index].term == request.last_log_term
 
             if vote_granted:
-                self._change_state(RaftState.FOLLOWER) # Avoiding race condition when Candidate. This is necessary to avoid excessive elections
+                self._change_state(
+                    RaftState.FOLLOWER
+                )  # Avoiding race condition when Candidate. This is necessary to avoid excessive elections
                 self._voted_for = client_node_id
             else:
-             _logger.info(
-                c["request_vote"]
-                + "Request vote request denied log is not up to date (self._log.term (%d) != request.last_log_term (%d) or already voted for another candidate in this term (%s))"
-                + c["end_color"],
-                self._log[request.last_log_index].term,
-                request.last_log_term,
-                self._voted_for,
-            )
+                _logger.info(
+                    c["request_vote"]
+                    + "Request vote request denied log is not up to date (self._log.term (%d) != request.last_log_term (%d) or already voted for another candidate in this term (%s))"
+                    + c["end_color"],
+                    self._log[request.last_log_index].term,
+                    request.last_log_term,
+                    self._voted_for,
+                )
 
-        return sirius_cyber_corp.RequestVote_1.Response(term=self._term, vote_granted=vote_granted)
+        return sirius_cyber_corp.RequestVote_1.Response(
+            term=self._term, vote_granted=vote_granted
+        )
 
     async def _start_election(self) -> None:
         """
@@ -254,15 +278,22 @@ class RaftNode:
         If the node receives a majority of votes, it will become the leader.
         If not, it will revert to follower state.
         """
-        assert self._state == RaftState.CANDIDATE, "Election can only be started by a candidate"
+        assert (
+            self._state == RaftState.CANDIDATE
+        ), "Election can only be started by a candidate"
 
-        _logger.info(c["raft_logic"] + "Node ID: %d -- Starting election" + c["end_color"], self._node.id)
+        _logger.info(
+            c["raft_logic"] + "Node ID: %d -- Starting election" + c["end_color"],
+            self._node.id,
+        )
         # Increment currentTerm
         self._term += 1
         # Vote for self
         self._voted_for = self._node.id
         # Send RequestVote RPCs to all other servers
-        last_log_index = len(self._log) - 1  # if log is empty (only entry is at index zero), last_log_index = 0
+        last_log_index = (
+            len(self._log) - 1
+        )  # if log is empty (only entry is at index zero), last_log_index = 0
         request = sirius_cyber_corp.RequestVote_1.Request(
             term=self._term,
             last_log_index=last_log_index,
@@ -271,17 +302,23 @@ class RaftNode:
         # Send request vote to all nodes in cluster, count votes
         number_of_nodes = len(self._cluster) + 1  # +1 for self
         number_of_votes = 1  # Vote for self
-        for remote_node_index, remote_client in enumerate(self._request_vote_clients):  # index allows to find node id
+        for remote_node_index, remote_client in enumerate(
+            self._request_vote_clients
+        ):  # index allows to find node id
             remote_node_id = self._cluster[remote_node_index]
             _logger.info(
-                c["raft_logic"] + "Node ID: %d -- Sending request vote to node %d" + c["end_color"],
+                c["raft_logic"]
+                + "Node ID: %d -- Sending request vote to node %d"
+                + c["end_color"],
                 self._node.id,
                 remote_node_id,
             )
             response = await remote_client(request)
             if response:
                 _logger.info(
-                    c["raft_logic"] + "Node ID: %d -- Response from node %d: %s" + c["end_color"],
+                    c["raft_logic"]
+                    + "Node ID: %d -- Response from node %d: %s"
+                    + c["end_color"],
                     self._node.id,
                     remote_node_id,
                     response,
@@ -290,17 +327,25 @@ class RaftNode:
                     number_of_votes += 1
             else:
                 _logger.info(
-                    c["raft_logic"] + "Node ID: %d -- No response from node %d" + c["end_color"],
+                    c["raft_logic"]
+                    + "Node ID: %d -- No response from node %d"
+                    + c["end_color"],
                     self._node.id,
                     remote_node_id,
                 )
 
         # If votes received from majority of servers: become leader
         if number_of_votes > number_of_nodes / 2:  # int(5/2) = 2, int(3/2) = 1
-            _logger.info(c["raft_logic"] + "Node ID: %d -- Became leader" + c["end_color"], self._node.id)
+            _logger.info(
+                c["raft_logic"] + "Node ID: %d -- Became leader" + c["end_color"],
+                self._node.id,
+            )
             self._change_state(RaftState.LEADER)
         else:
-            _logger.info(c["raft_logic"] + "Node ID: %d -- Election failed" + c["end_color"], self._node.id)
+            _logger.info(
+                c["raft_logic"] + "Node ID: %d -- Election failed" + c["end_color"],
+                self._node.id,
+            )
             # If election fails, revert to follower
             self._voted_for = None
             self._change_state(RaftState.FOLLOWER)
@@ -319,7 +364,9 @@ class RaftNode:
         3) If the above checks have passed, it will call _append_entries_processing to append the new entry to the log.
         """
         _logger.info(
-            c["append_entries"] + "Node ID: %d -- Append entries request %s from node %d" + c["end_color"],
+            c["append_entries"]
+            + "Node ID: %d -- Append entries request %s from node %d"
+            + c["end_color"],
             self._node.id,
             request,
             metadata.client_node_id,
@@ -329,23 +376,41 @@ class RaftNode:
         if len(request.log_entry) == 0:  # empty means heartbeat
             if request.term < self._term:
                 _logger.info(
-                    c["append_entries"] + "Node ID: %d -- Heartbeat denied (term < currentTerm)" + c["end_color"],
+                    c["append_entries"]
+                    + "Node ID: %d -- Heartbeat denied (term < currentTerm)"
+                    + c["end_color"],
                     self._node.id,
                 )
-                return sirius_cyber_corp.AppendEntries_1.Response(term=self._term, success=False)
+                return sirius_cyber_corp.AppendEntries_1.Response(
+                    term=self._term, success=False
+                )
             else:  # request.term >= self._term
-                _logger.info(c["append_entries"] + "Node ID: %d -- Heartbeat received" + c["end_color"], self._node.id)
-                if metadata.client_node_id != self._voted_for and request.term > self._term:
+                _logger.info(
+                    c["append_entries"]
+                    + "Node ID: %d -- Heartbeat received"
+                    + c["end_color"],
+                    self._node.id,
+                )
+                if (
+                    metadata.client_node_id != self._voted_for
+                    and request.term > self._term
+                ):
                     _logger.info(
-                        c["append_entries"] + "Node ID: %d -- Heartbeat from new leader: %d" + c["end_color"],
+                        c["append_entries"]
+                        + "Node ID: %d -- Heartbeat from new leader: %d"
+                        + c["end_color"],
                         self._node.id,
                         metadata.client_node_id,
                     )
                     self._voted_for = metadata.client_node_id
-                self._change_state(RaftState.FOLLOWER)  # this will reset the election timeout as well
+                self._change_state(
+                    RaftState.FOLLOWER
+                )  # this will reset the election timeout as well
                 self._term = request.term  # update term
 
-                return sirius_cyber_corp.AppendEntries_1.Response(term=self._term, success=True)
+                return sirius_cyber_corp.AppendEntries_1.Response(
+                    term=self._term, success=True
+                )
 
         # Reply false if term < currentTerm (§5.1)
         if request.term < self._term:
@@ -355,9 +420,11 @@ class RaftNode:
                 + c["end_color"],
                 self._node.id,
                 request.term,
-                self._term
+                self._term,
             )
-            return sirius_cyber_corp.AppendEntries_1.Response(term=self._term, success=False)
+            return sirius_cyber_corp.AppendEntries_1.Response(
+                term=self._term, success=False
+            )
 
         # Reply false if log doesn’t contain an entry at prevLogIndex
         # whose term matches prevLogTerm (§5.3)
@@ -369,18 +436,23 @@ class RaftNode:
                     + c["end_color"],
                     self._node.id,
                 )
-                return sirius_cyber_corp.AppendEntries_1.Response(term=self._term, success=False)
+                return sirius_cyber_corp.AppendEntries_1.Response(
+                    term=self._term, success=False
+                )
         except IndexError as e:
             _logger.info(
-            c["append_entries"]
-            + "Node ID: %d -- Append entries request denied (log mismatch 2). IndexError: %s. "
-            + "prev_log_index: %d, log_length: %d"
-            + c["end_color"],
-            self._node.id,
-            str(e),
-            request.prev_log_index,
-            len(self._log))
-            return sirius_cyber_corp.AppendEntries_1.Response(term=self._term, success=False)
+                c["append_entries"]
+                + "Node ID: %d -- Append entries request denied (log mismatch 2). IndexError: %s. "
+                + "prev_log_index: %d, log_length: %d"
+                + c["end_color"],
+                self._node.id,
+                str(e),
+                request.prev_log_index,
+                len(self._log),
+            )
+            return sirius_cyber_corp.AppendEntries_1.Response(
+                term=self._term, success=False
+            )
 
         self._append_entries_processing(request)
         return sirius_cyber_corp.AppendEntries_1.Response(term=self._term, success=True)
@@ -392,23 +464,34 @@ class RaftNode:
         """
         This method is called when the append entries request passes all checks and can be appended to the log.
         """
-        assert len(request.log_entry) == 1  # in our implementation only a single entry is sent at a time
+        assert (
+            len(request.log_entry) == 1
+        )  # in our implementation only a single entry is sent at a time
 
         # If an existing entry conflicts with a new one (same index but different terms),
         # delete the existing entry and all that follow it (§5.3)
         new_index = request.prev_log_index + 1
-        _logger.info(c["append_entries"] + "Node ID: %d -- new_index: %d" + c["end_color"], self._node.id, new_index)
+        _logger.info(
+            c["append_entries"] + "Node ID: %d -- new_index: %d" + c["end_color"],
+            self._node.id,
+            new_index,
+        )
         for log_index, log_entry in enumerate(self._log[1:]):
             if (
-                log_index + 1  # index + 1 because we skip the first entry (self._log[1:])
+                log_index
+                + 1  # index + 1 because we skip the first entry (self._log[1:])
             ) == new_index and log_entry.term != request.log_entry[0].term:
                 _logger.info(
-                    c["append_entries"] + "Node ID: %d -- deleting from: %d" + c["end_color"],
+                    c["append_entries"]
+                    + "Node ID: %d -- deleting from: %d"
+                    + c["end_color"],
                     self._node.id,
                     log_index + 1,
                 )
                 number_of_entries_to_delete = len(self._log) - (log_index + 1)
-                self._next_index = [x - number_of_entries_to_delete for x in self._next_index]
+                self._next_index = [
+                    x - number_of_entries_to_delete for x in self._next_index
+                ]
                 del self._log[log_index + 1 :]
                 self._commit_index = log_index
                 break
@@ -423,13 +506,21 @@ class RaftNode:
             and self._log[new_index].entry.value == request.log_entry[0].entry.value
         ):  # log comparison can be done better, once this is fixed: https://github.com/OpenCyphal/pycyphal/issues/297
             append_new_entry = False
-            _logger.info(c["append_entries"] + "Node ID: %d -- entry already exists" + c["end_color"], self._node.id)
+            _logger.info(
+                c["append_entries"]
+                + "Node ID: %d -- entry already exists"
+                + c["end_color"],
+                self._node.id,
+            )
         # 2. If it does not exist, append it
         if append_new_entry:
             if new_index < len(self._log):
-                _logger.info("new_index < len(self._log): %s", new_index < len(self._log))
                 _logger.info(
-                    "self._log[new_index] == request.log_entry[0]: %s", self._log[new_index] == request.log_entry[0]
+                    "new_index < len(self._log): %s", new_index < len(self._log)
+                )
+                _logger.info(
+                    "self._log[new_index] == request.log_entry[0]: %s",
+                    self._log[new_index] == request.log_entry[0],
                 )
                 assert False
             self._log.append(request.log_entry[0])
@@ -440,7 +531,9 @@ class RaftNode:
                 request.log_entry[0],
             )
             _logger.info(
-                c["append_entries"] + "Node ID: %d -- commit_index: %d" + c["end_color"],
+                c["append_entries"]
+                + "Node ID: %d -- commit_index: %d"
+                + c["end_color"],
                 self._node.id,
                 self._commit_index,
             )
@@ -455,9 +548,10 @@ class RaftNode:
 
         # Update current_term (if follower) (leaders will update their own term on timeout)
         if self._state == RaftState.FOLLOWER:
-            self._change_state(RaftState.FOLLOWER)  # this will reset the election timeout as well
+            self._change_state(
+                RaftState.FOLLOWER
+            )  # this will reset the election timeout as well
             self._term = request.log_entry[0].term
-            
 
     async def _send_heartbeat(self, remote_node_index: int) -> None:
         """
@@ -476,7 +570,9 @@ class RaftNode:
         remote_node_id = self._cluster[remote_node_index]
         remote_client = self._append_entries_clients[remote_node_index]
         _logger.info(
-            c["raft_logic"] + "Node ID: %d -- Sending heartbeat to node %d" + c["end_color"],
+            c["raft_logic"]
+            + "Node ID: %d -- Sending heartbeat to node %d"
+            + c["end_color"],
             self._node.id,
             remote_node_id,
         )
@@ -489,14 +585,18 @@ class RaftNode:
             log_entry=None,  # heartbeat has no log entry
         )
         _logger.info(
-            c["raft_logic"] + "Node ID: %d -- prev_log_index: %d, prev_log_term: %d" + c["end_color"],
+            c["raft_logic"]
+            + "Node ID: %d -- prev_log_index: %d, prev_log_term: %d"
+            + c["end_color"],
             self._node.id,
             request.prev_log_index,
             request.prev_log_term,
         )
         assert len(request.log_entry) == 0, "Heartbeat should not have a log entry"
         try:
-            response = await remote_client(request)  # metadata is filled out by the client
+            response = await remote_client(
+                request
+            )  # metadata is filled out by the client
         except pycyphal.presentation._port._error.PortClosedError:
             _logger.info(
                 c["raft_logic"]
@@ -509,7 +609,9 @@ class RaftNode:
         if response:
             if response.success:
                 _logger.info(
-                    c["raft_logic"] + "Node ID: %d -- heartbeat to node %d was successful" + c["end_color"],
+                    c["raft_logic"]
+                    + "Node ID: %d -- heartbeat to node %d was successful"
+                    + c["end_color"],
                     self._node.id,
                     remote_node_id,
                 )
@@ -531,7 +633,9 @@ class RaftNode:
                         # (which could have changed due a heartbeat from another leader, see _unittest_raft_fsm_2, stage 5/6)
                         return
                     _logger.info(
-                        c["raft_logic"] + "Node ID: %d -- heartbeat to node %d failed (Log mismatch)" + c["end_color"],
+                        c["raft_logic"]
+                        + "Node ID: %d -- heartbeat to node %d failed (Log mismatch)"
+                        + c["end_color"],
                         self._node.id,
                         remote_node_id,
                     )
@@ -542,7 +646,9 @@ class RaftNode:
                     pass  # do nothing, we are no longer the leader
         else:
             _logger.info(
-                c["raft_logic"] + "Node ID: %d -- heartbeat to node %d failed (unreachable)" + c["end_color"],
+                c["raft_logic"]
+                + "Node ID: %d -- heartbeat to node %d failed (unreachable)"
+                + c["end_color"],
                 self._node.id,
                 remote_node_id,
             )
@@ -553,7 +659,9 @@ class RaftNode:
         It works a very similar manner to _send_hearbeat, except that it sends a single log entry.
         """
 
-        assert self._state == RaftState.LEADER, "Only the leader can request append entry"
+        assert (
+            self._state == RaftState.LEADER
+        ), "Only the leader can request append entry"
 
         _logger.info(
             c["raft_logic"]
@@ -570,9 +678,13 @@ class RaftNode:
             prev_log_term=self._log[remote_next_index - 1].term,
             log_entry=self._log[remote_next_index],
         )
-        assert len(request.log_entry) == 1, "Append entry should have a (single) log entry"
+        assert (
+            len(request.log_entry) == 1
+        ), "Append entry should have a (single) log entry"
         try:
-            response = await remote_client(request)  # metadata is filled out by the client
+            response = await remote_client(
+                request
+            )  # metadata is filled out by the client
         except pycyphal.presentation._port._error.PortClosedError:
             _logger.info(
                 c["raft_logic"]
@@ -585,7 +697,9 @@ class RaftNode:
         if response:
             if response.success:
                 _logger.info(
-                    c["raft_logic"] + "Node ID: %d -- Remote node %d log updated" + c["end_color"],
+                    c["raft_logic"]
+                    + "Node ID: %d -- Remote node %d log updated"
+                    + c["end_color"],
                     self._node.id,
                     self._cluster[remote_node_index],
                 )
@@ -612,7 +726,9 @@ class RaftNode:
                     pass
         else:
             _logger.info(
-                c["raft_logic"] + "Node ID: %d -- Remote node %d log update failed (unreachable)" + c["end_color"],
+                c["raft_logic"]
+                + "Node ID: %d -- Remote node %d log update failed (unreachable)"
+                + c["end_color"],
                 self._node.id,
                 self._cluster[remote_node_index],
             )
@@ -622,14 +738,25 @@ class RaftNode:
         request: uavcan.node.ExecuteCommand_1.Request,
         metadata: pycyphal.presentation.ServiceRequestMetadata,
     ) -> uavcan.node.ExecuteCommand_1.Response:
-        _logger.info("Execute command request %s from node %d", request, metadata.client_node_id)
-        if request.command == uavcan.node.ExecuteCommand_1.Request.COMMAND_FACTORY_RESET:
+        _logger.info(
+            "Execute command request %s from node %d", request, metadata.client_node_id
+        )
+        if (
+            request.command
+            == uavcan.node.ExecuteCommand_1.Request.COMMAND_FACTORY_RESET
+        ):
             try:
-                os.unlink(RaftNode.REGISTER_FILE)  # Reset to defaults by removing the register file.
+                os.unlink(
+                    RaftNode.REGISTER_FILE
+                )  # Reset to defaults by removing the register file.
             except OSError:  # Do nothing if already removed.
                 pass
-            return uavcan.node.ExecuteCommand_1.Response(uavcan.node.ExecuteCommand_1.Response.STATUS_SUCCESS)
-        return uavcan.node.ExecuteCommand_1.Response(uavcan.node.ExecuteCommand_1.Response.STATUS_BAD_COMMAND)
+            return uavcan.node.ExecuteCommand_1.Response(
+                uavcan.node.ExecuteCommand_1.Response.STATUS_SUCCESS
+            )
+        return uavcan.node.ExecuteCommand_1.Response(
+            uavcan.node.ExecuteCommand_1.Response.STATUS_BAD_COMMAND
+        )
 
     def _change_state(self, new_state: RaftState) -> None:
         """
@@ -648,7 +775,12 @@ class RaftNode:
         self._prev_state = self._state
         self._state = new_state
 
-        _logger.info("Node ID: %d -- Changing state from %s to %s", self._node.id, self._prev_state, self._state)
+        _logger.info(
+            "Node ID: %d -- Changing state from %s to %s",
+            self._node.id,
+            self._prev_state,
+            self._state,
+        )
 
         if self._state == RaftState.FOLLOWER:
             # Cancel the term timeout (if it exists), and schedule a new election timeout.
@@ -664,7 +796,7 @@ class RaftNode:
                 self._election_timer.cancel()
         elif self._state == RaftState.LEADER:
             assert self._prev_state == RaftState.CANDIDATE, "Invalid state change 3"
-            
+
             # Cancel the election timeout (if it exists), and schedule a new term timeout.
             if hasattr(self, "_election_timer"):
                 self._election_timer.cancel()
@@ -676,33 +808,55 @@ class RaftNode:
         """
         If a follower receives a heartbeat from the leader, it should reset its election timeout.
         """
-        assert self._state == RaftState.FOLLOWER, "Only followers should reset the election timeout"
-        _logger.info(c["raft_logic"] + "Node ID: %d -- Resetting election timeout" + c["end_color"], self._node.id)
+        assert (
+            self._state == RaftState.FOLLOWER
+        ), "Only followers should reset the election timeout"
+        _logger.info(
+            c["raft_logic"]
+            + "Node ID: %d -- Resetting election timeout"
+            + c["end_color"],
+            self._node.id,
+        )
         loop = asyncio.get_event_loop()
         if hasattr(self, "_election_timer"):
             self._election_timer.cancel()
         self._election_timer = loop.call_later(
-            self._election_timeout, lambda: asyncio.create_task(self._on_election_timeout())
+            self._election_timeout,
+            lambda: asyncio.create_task(self._on_election_timeout()),
         )
 
     def _reset_term_timeout(self) -> None:
         """
         Once a term timeout is reached, another term callback is scheduled.
         """
-        assert self._state == RaftState.LEADER, "Only leaders should reset the term timeout"
-        _logger.info(c["raft_logic"] + "Node ID: %d -- Resetting term timeout" + c["end_color"], self._node.id)
+        assert (
+            self._state == RaftState.LEADER
+        ), "Only leaders should reset the term timeout"
+        _logger.info(
+            c["raft_logic"] + "Node ID: %d -- Resetting term timeout" + c["end_color"],
+            self._node.id,
+        )
         loop = asyncio.get_event_loop()
         if hasattr(self, "_term_timer"):
             self._term_timer.cancel()
-        self._term_timer = loop.call_later(self._term_timeout, lambda: asyncio.create_task(self._on_term_timeout()))
+        self._term_timer = loop.call_later(
+            self._term_timeout, lambda: asyncio.create_task(self._on_term_timeout())
+        )
 
     async def _on_election_timeout(self) -> None:
         """
         This function is called upon election timeout.
         The node starts an election and then restarts the election timeout.
         """
-        assert self._state == RaftState.FOLLOWER, "Only followers have an election timeout"
-        _logger.info(c["raft_logic"] + "Node ID: %d -- Election timeout reached" + c["end_color"], self._node.id)
+        assert (
+            self._state == RaftState.FOLLOWER
+        ), "Only followers have an election timeout"
+        _logger.info(
+            c["raft_logic"]
+            + "Node ID: %d -- Election timeout reached"
+            + c["end_color"],
+            self._node.id,
+        )
         self._change_state(RaftState.CANDIDATE)
         await self._start_election()
 
@@ -714,7 +868,9 @@ class RaftNode:
         - if the remote node log is not up to date, it will send an append entries request
         """
         _logger.info(
-            c["raft_logic"] + "Node ID: %d -- Term timeout reached, new term: %d" + c["end_color"],
+            c["raft_logic"]
+            + "Node ID: %d -- Term timeout reached, new term: %d"
+            + c["end_color"],
             self._node.id,
             self._term,
         )
@@ -765,14 +921,16 @@ class RaftNode:
         if self._state == RaftState.FOLLOWER:
             self._next_election_timeout = loop.time() + self._election_timeout
             self._term_timer = loop.call_at(
-                self._next_election_timeout, lambda: asyncio.create_task(self._on_election_timeout())
+                self._next_election_timeout,
+                lambda: asyncio.create_task(self._on_election_timeout()),
             )
 
         # Schedule term timeout (only for leader)
         if self._state == RaftState.LEADER:
             self._next_term_timeout = loop.time() + self._term_timeout
             self._term_timer = loop.call_at(
-                self._next_term_timeout, lambda: asyncio.create_task(self._on_term_timeout())
+                self._next_term_timeout,
+                lambda: asyncio.create_task(self._on_term_timeout()),
             )
 
     def close(self) -> None:

--- a/cyraft/node.py
+++ b/cyraft/node.py
@@ -631,6 +631,17 @@ class RaftNode:
 
         if self._state == RaftState.FOLLOWER:
             # Cancel the term timeout (if it exists), and schedule a new election timeout.
+            for remote_node_index, remote_next_index in enumerate(self._next_index):
+                _logger.info(
+                    c["raft_logic"]
+                    + "Node ID: %d -- Value of next index = %d and value of remote next index = %s for node %s"
+                    + c["end_color"],
+                    self._node.id,
+                    self._commit_index,
+                    remote_next_index,
+                    self._cluster[remote_node_index],
+                )
+
             if hasattr(self, "_term_timer"):
                 self._term_timer.cancel()  # FOLLOWER should not have term timer
             self._reset_election_timeout()  # FOLLOWER should have election timer

--- a/cyraft/node.py
+++ b/cyraft/node.py
@@ -208,8 +208,11 @@ class RaftNode:
         if request.term < self._term or (self._voted_for is not None):
             _logger.info(
                 c["request_vote"]
-                + "Request vote request denied (term < self._term or already voted for another candidate in this term)"
-                + c["end_color"]
+                + "Request vote request denied (term (%d) < self._term (%d) or already voted for another candidate in this term (%s))"
+                + c["end_color"],
+                request.term,
+                self._term,
+                self._voted_for,
             )
             return sirius_cyber_corp.RequestVote_1.Response(term=self._term, vote_granted=False)
 
@@ -338,15 +341,18 @@ class RaftNode:
                     self._voted_for = metadata.client_node_id
                 self._change_state(RaftState.FOLLOWER)  # this will reset the election timeout as well
                 self._term = request.term  # update term
+
                 return sirius_cyber_corp.AppendEntries_1.Response(term=self._term, success=True)
 
         # Reply false if term < currentTerm (§5.1)
         if request.term < self._term:
             _logger.info(
                 c["append_entries"]
-                + "Node ID: %d -- Append entries request denied (term < currentTerm)"
+                + "Node ID: %d -- Append entries request denied (term (%d) < currentTerm (%d))"
                 + c["end_color"],
                 self._node.id,
+                request.term,
+                self._term
             )
             return sirius_cyber_corp.AppendEntries_1.Response(term=self._term, success=False)
 
@@ -617,6 +623,17 @@ class RaftNode:
 
         if self._state == RaftState.FOLLOWER:
             # Cancel the term timeout (if it exists), and schedule a new election timeout.
+            for remote_node_index, remote_next_index in enumerate(self._next_index):
+                _logger.info(
+                    c["raft_logic"]
+                    + "Node ID: %d -- Value of next index = %d and value of remote next index = %s for node %s"
+                    + c["end_color"],
+                    self._node.id,
+                    self._commit_index,
+                    remote_next_index,
+                    self._cluster[remote_node_index],
+                )
+
             if hasattr(self, "_term_timer"):
                 self._term_timer.cancel()  # FOLLOWER should not have term timer
             self._reset_election_timeout()  # FOLLOWER should have election timer
@@ -629,6 +646,7 @@ class RaftNode:
                 self._election_timer.cancel()
         elif self._state == RaftState.LEADER:
             assert self._prev_state == RaftState.CANDIDATE, "Invalid state change 3"
+            
             # Cancel the election timeout (if it exists), and schedule a new term timeout.
             if hasattr(self, "_election_timer"):
                 self._election_timer.cancel()
@@ -690,6 +708,17 @@ class RaftNode:
             if self._state != RaftState.LEADER:
                 # if the node is no longer a leader, stop sending heartbeats
                 break
+
+            _logger.info(
+                c["raft_logic"]
+                + "Node ID: %d -- Value of next index = %d and value of remote next index = %s for node %s"
+                + c["end_color"],
+                self._node.id,
+                self._commit_index,
+                remote_next_index,
+                self._cluster[remote_node_index],
+            )
+
             if self._commit_index + 1 == remote_next_index:  # remote log is up to date
                 _logger.info(
                     c["raft_logic"]

--- a/demo/demo_cyraft.py
+++ b/demo/demo_cyraft.py
@@ -10,7 +10,7 @@ import os
 import sys
 
 # Get the absolute path of the parent directory
-parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 # Add the parent directory to the Python path
 sys.path.append(parent_dir)
 # This can be removed if setting PYTHONPATH (export PYTHONPATH=cyraft)

--- a/tests/raft_leader_election.py
+++ b/tests/raft_leader_election.py
@@ -25,7 +25,7 @@ import time
 
 # Add parent directory to Python path
 # Get the absolute path of the parent directory
-parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 # Add the parent directory to the Python path
 sys.path.append(parent_dir)
 # This can be removed if setting PYTHONPATH (export PYTHONPATH=cyraft)
@@ -136,7 +136,9 @@ async def _unittest_raft_fsm_1() -> None:
     assert raft_node_3._term == 0
     assert raft_node_3._voted_for is None
 
-    _logger.info("================== TEST STAGE 2/3: LEADER election ==================")
+    _logger.info(
+        "================== TEST STAGE 2/3: LEADER election =================="
+    )
 
     # node 1 should have a smaller election timeout than others
     raft_node_1.election_timeout = ELECTION_TIMEOUT - 1
@@ -149,9 +151,7 @@ async def _unittest_raft_fsm_1() -> None:
 
     assert raft_node_1._prev_state == RaftState.CANDIDATE
     assert raft_node_1._state == RaftState.LEADER
-    assert (
-        raft_node_1._term == 1
-    ), "+1 due to starting election"
+    assert raft_node_1._term == 1, "+1 due to starting election"
     assert raft_node_1._voted_for == 41
 
     assert raft_node_2._prev_state == RaftState.FOLLOWER
@@ -164,10 +164,16 @@ async def _unittest_raft_fsm_1() -> None:
     assert raft_node_3._term == 1, "received heartbeat from LEADER"
     assert raft_node_3._voted_for == 41
 
-    assert raft_node_1._term >= raft_node_2._term, "LEADER term should be higher (or equal) than FOLLOWER"
-    assert raft_node_1._term >= raft_node_3._term, "LEADER term should be higher (or equal) than FOLLOWER"
+    assert (
+        raft_node_1._term >= raft_node_2._term
+    ), "LEADER term should be higher (or equal) than FOLLOWER"
+    assert (
+        raft_node_1._term >= raft_node_3._term
+    ), "LEADER term should be higher (or equal) than FOLLOWER"
 
-    _logger.info("================== TEST STAGE 4: LEADER maintains leadership ==================")
+    _logger.info(
+        "================== TEST STAGE 4: LEADER maintains leadership =================="
+    )
 
     await asyncio.sleep(ELECTION_TIMEOUT)
 
@@ -192,7 +198,9 @@ async def _unittest_raft_fsm_1() -> None:
     raft_node_1.close()
     raft_node_2.close()
     raft_node_3.close()
-    _logger.info("================== DOES SOMETHING HAPPEN AFTER THIS? ==================")
+    _logger.info(
+        "================== DOES SOMETHING HAPPEN AFTER THIS? =================="
+    )
     await asyncio.sleep(10)
 
 
@@ -207,7 +215,9 @@ async def _unittest_raft_fsm_2():
     TERM_TIMEOUT = 0.5
     ELECTION_TIMEOUT = 5
 
-    _logger.info("================== TEST STAGE 5/6: node with higher term gets elected ==================")
+    _logger.info(
+        "================== TEST STAGE 5/6: node with higher term gets elected =================="
+    )
 
     os.environ["UAVCAN__NODE__ID"] = "41"
     raft_node_1 = RaftNode()
@@ -220,7 +230,9 @@ async def _unittest_raft_fsm_2():
     os.environ["UAVCAN__NODE__ID"] = "43"
     raft_node_3 = RaftNode()
     raft_node_3.term_timeout = TERM_TIMEOUT
-    raft_node_3.election_timeout = ELECTION_TIMEOUT + 1  # we don't want this node starting any elections
+    raft_node_3.election_timeout = (
+        ELECTION_TIMEOUT + 1
+    )  # we don't want this node starting any elections
 
     # make all part of the same cluster
     cluster = [raft_node_1._node.id, raft_node_2._node.id, raft_node_3._node.id]
@@ -233,7 +245,9 @@ async def _unittest_raft_fsm_2():
     raft_node_1._change_state(RaftState.LEADER)
     raft_node_1._voted_for = 41
     raft_node_1._term = 1
-    raft_node_2._change_state(RaftState.CANDIDATE)  # this is not strictly necessary, but it's more realistic
+    raft_node_2._change_state(
+        RaftState.CANDIDATE
+    )  # this is not strictly necessary, but it's more realistic
     raft_node_2._change_state(RaftState.LEADER)
     raft_node_2._voted_for = 42
     raft_node_2._term = 2
@@ -242,7 +256,9 @@ async def _unittest_raft_fsm_2():
     asyncio.create_task(raft_node_2.run())
     asyncio.create_task(raft_node_3.run())
 
-    await asyncio.sleep(ELECTION_TIMEOUT + 0.1)  # + 0.1 is necesary to make sure the last term timeout is processed
+    await asyncio.sleep(
+        ELECTION_TIMEOUT + 0.1
+    )  # + 0.1 is necesary to make sure the last term timeout is processed
 
     # assert raft_node_1._prev_state == RaftState.LEADER
     assert raft_node_1._state == RaftState.FOLLOWER
@@ -305,7 +321,9 @@ async def _unittest_raft_fsm_3():
     # node 1 is CANDIDATE, node 2 is LEADER
     raft_node_1._change_state(RaftState.CANDIDATE)
     raft_node_1._voted_for = 41
-    raft_node_2._change_state(RaftState.CANDIDATE)  # this is not strictly necessary, but it's more realistic
+    raft_node_2._change_state(
+        RaftState.CANDIDATE
+    )  # this is not strictly necessary, but it's more realistic
     raft_node_2._change_state(RaftState.LEADER)
     raft_node_2._voted_for = 42
     raft_node_2._term = 1
@@ -353,7 +371,9 @@ async def _unittest_raft_fsm_4():
     TERM_TIMEOUT = 0.5
     ELECTION_TIMEOUT = 5
 
-    _logger.info("================== TEST STAGE 9/10: 2 CANDIDATEs, higher term get's elected ==================")
+    _logger.info(
+        "================== TEST STAGE 9/10: 2 CANDIDATEs, higher term get's elected =================="
+    )
 
     os.environ["UAVCAN__NODE__ID"] = "41"
     raft_node_1 = RaftNode()

--- a/tests/raft_leader_election.py
+++ b/tests/raft_leader_election.py
@@ -136,9 +136,7 @@ async def _unittest_raft_fsm_1() -> None:
     assert raft_node_3._term == 0
     assert raft_node_3._voted_for is None
 
-    _logger.info(
-        "================== TEST STAGE 2/3: LEADER election =================="
-    )
+    _logger.info("================== TEST STAGE 2/3: LEADER election ==================")
 
     # node 1 should have a smaller election timeout than others
     raft_node_1.election_timeout = ELECTION_TIMEOUT - 1
@@ -164,16 +162,10 @@ async def _unittest_raft_fsm_1() -> None:
     assert raft_node_3._term == 1, "received heartbeat from LEADER"
     assert raft_node_3._voted_for == 41
 
-    assert (
-        raft_node_1._term >= raft_node_2._term
-    ), "LEADER term should be higher (or equal) than FOLLOWER"
-    assert (
-        raft_node_1._term >= raft_node_3._term
-    ), "LEADER term should be higher (or equal) than FOLLOWER"
+    assert raft_node_1._term >= raft_node_2._term, "LEADER term should be higher (or equal) than FOLLOWER"
+    assert raft_node_1._term >= raft_node_3._term, "LEADER term should be higher (or equal) than FOLLOWER"
 
-    _logger.info(
-        "================== TEST STAGE 4: LEADER maintains leadership =================="
-    )
+    _logger.info("================== TEST STAGE 4: LEADER maintains leadership ==================")
 
     await asyncio.sleep(ELECTION_TIMEOUT)
 
@@ -198,9 +190,7 @@ async def _unittest_raft_fsm_1() -> None:
     raft_node_1.close()
     raft_node_2.close()
     raft_node_3.close()
-    _logger.info(
-        "================== DOES SOMETHING HAPPEN AFTER THIS? =================="
-    )
+    _logger.info("================== DOES SOMETHING HAPPEN AFTER THIS? ==================")
     await asyncio.sleep(10)
 
 
@@ -215,9 +205,7 @@ async def _unittest_raft_fsm_2():
     TERM_TIMEOUT = 0.5
     ELECTION_TIMEOUT = 5
 
-    _logger.info(
-        "================== TEST STAGE 5/6: node with higher term gets elected =================="
-    )
+    _logger.info("================== TEST STAGE 5/6: node with higher term gets elected ==================")
 
     os.environ["UAVCAN__NODE__ID"] = "41"
     raft_node_1 = RaftNode()
@@ -230,9 +218,7 @@ async def _unittest_raft_fsm_2():
     os.environ["UAVCAN__NODE__ID"] = "43"
     raft_node_3 = RaftNode()
     raft_node_3.term_timeout = TERM_TIMEOUT
-    raft_node_3.election_timeout = (
-        ELECTION_TIMEOUT + 1
-    )  # we don't want this node starting any elections
+    raft_node_3.election_timeout = ELECTION_TIMEOUT + 1  # we don't want this node starting any elections
 
     # make all part of the same cluster
     cluster = [raft_node_1._node.id, raft_node_2._node.id, raft_node_3._node.id]
@@ -245,9 +231,7 @@ async def _unittest_raft_fsm_2():
     raft_node_1._change_state(RaftState.LEADER)
     raft_node_1._voted_for = 41
     raft_node_1._term = 1
-    raft_node_2._change_state(
-        RaftState.CANDIDATE
-    )  # this is not strictly necessary, but it's more realistic
+    raft_node_2._change_state(RaftState.CANDIDATE)  # this is not strictly necessary, but it's more realistic
     raft_node_2._change_state(RaftState.LEADER)
     raft_node_2._voted_for = 42
     raft_node_2._term = 2
@@ -256,9 +240,7 @@ async def _unittest_raft_fsm_2():
     asyncio.create_task(raft_node_2.run())
     asyncio.create_task(raft_node_3.run())
 
-    await asyncio.sleep(
-        ELECTION_TIMEOUT + 0.1
-    )  # + 0.1 is necesary to make sure the last term timeout is processed
+    await asyncio.sleep(ELECTION_TIMEOUT + 0.1)  # + 0.1 is necesary to make sure the last term timeout is processed
 
     # assert raft_node_1._prev_state == RaftState.LEADER
     assert raft_node_1._state == RaftState.FOLLOWER
@@ -321,9 +303,7 @@ async def _unittest_raft_fsm_3():
     # node 1 is CANDIDATE, node 2 is LEADER
     raft_node_1._change_state(RaftState.CANDIDATE)
     raft_node_1._voted_for = 41
-    raft_node_2._change_state(
-        RaftState.CANDIDATE
-    )  # this is not strictly necessary, but it's more realistic
+    raft_node_2._change_state(RaftState.CANDIDATE)  # this is not strictly necessary, but it's more realistic
     raft_node_2._change_state(RaftState.LEADER)
     raft_node_2._voted_for = 42
     raft_node_2._term = 1
@@ -371,9 +351,7 @@ async def _unittest_raft_fsm_4():
     TERM_TIMEOUT = 0.5
     ELECTION_TIMEOUT = 5
 
-    _logger.info(
-        "================== TEST STAGE 9/10: 2 CANDIDATEs, higher term get's elected =================="
-    )
+    _logger.info("================== TEST STAGE 9/10: 2 CANDIDATEs, higher term get's elected ==================")
 
     os.environ["UAVCAN__NODE__ID"] = "41"
     raft_node_1 = RaftNode()

--- a/tests/raft_log_replication.py
+++ b/tests/raft_log_replication.py
@@ -313,7 +313,7 @@ async def _unittest_raft_log_replication() -> None:
 
     for index, new_entry in enumerate(new_entries):
         request = sirius_cyber_corp.AppendEntries_1.Request(
-            term=raft_node_1._term,
+            term=1,
             prev_log_index=index + 1,  # index: 1, 2
             prev_log_term=raft_node_1._log[index + 1].term,
             log_entry=new_entry,
@@ -378,7 +378,7 @@ async def _unittest_raft_log_replication() -> None:
         ),
     )
     request = sirius_cyber_corp.AppendEntries_1.Request(
-        term=raft_node_1._term,
+        term=1,
         prev_log_index=2,  # index of top_2
         prev_log_term=raft_node_1._log[2].term,
         log_entry=new_entry,

--- a/tests/raft_log_replication.py
+++ b/tests/raft_log_replication.py
@@ -178,9 +178,7 @@ async def _unittest_raft_log_replication() -> None:
     # check if the new entry is replicated in the leader node
     assert len(raft_node_1._log) == 1 + 3
     assert raft_node_1._log[0].term == 0
-    assert (
-        raft_node_1._log[0].entry.name.value.tobytes().decode("utf-8") == ""
-    )  # index zero entry is empty
+    assert raft_node_1._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
     assert raft_node_1._log[0].entry.value == 0
     assert raft_node_1._log[1].term == 0
     assert raft_node_1._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
@@ -196,9 +194,7 @@ async def _unittest_raft_log_replication() -> None:
     # check if the new entry is replicated in the follower nodes
     assert len(raft_node_2._log) == 1 + 3
     assert raft_node_2._log[0].term == 0
-    assert (
-        raft_node_2._log[0].entry.name.value.tobytes().decode("utf-8") == ""
-    )  # index zero entry is empty
+    assert raft_node_2._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
     assert raft_node_2._log[0].entry.value == 0
     assert raft_node_2._log[1].term == 0
     assert raft_node_2._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
@@ -212,9 +208,7 @@ async def _unittest_raft_log_replication() -> None:
     assert raft_node_2._commit_index == 3
     assert len(raft_node_3._log) == 1 + 3
     assert raft_node_3._log[0].term == 0
-    assert (
-        raft_node_3._log[0].entry.name.value.tobytes().decode("utf-8") == ""
-    )  # index zero entry is empty
+    assert raft_node_3._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
     assert raft_node_3._log[0].entry.value == 0
     assert raft_node_3._log[1].term == 0
     assert raft_node_3._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
@@ -227,9 +221,7 @@ async def _unittest_raft_log_replication() -> None:
     assert raft_node_3._log[3].entry.value == 9
     assert raft_node_3._commit_index == 3
 
-    _logger.info(
-        "================== TEST 2: Replace log entry 3 with a new entry =================="
-    )
+    _logger.info("================== TEST 2: Replace log entry 3 with a new entry ==================")
 
     new_entry = sirius_cyber_corp.LogEntry_1(
         term=1,
@@ -257,9 +249,7 @@ async def _unittest_raft_log_replication() -> None:
 
     assert len(raft_node_1._log) == 1 + 3
     assert raft_node_1._log[0].term == 0
-    assert (
-        raft_node_1._log[0].entry.name.value.tobytes().decode("utf-8") == ""
-    )  # index zero entry is empty
+    assert raft_node_1._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
     assert raft_node_1._log[0].entry.value == 0
     assert raft_node_1._log[1].term == 0
     assert raft_node_1._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
@@ -275,9 +265,7 @@ async def _unittest_raft_log_replication() -> None:
     # check if the new entry is replicated in the follower nodes
     assert len(raft_node_2._log) == 1 + 3
     assert raft_node_2._log[0].term == 0
-    assert (
-        raft_node_2._log[0].entry.name.value.tobytes().decode("utf-8") == ""
-    )  # index zero entry is empty
+    assert raft_node_2._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
     assert raft_node_2._log[0].entry.value == 0
     assert raft_node_2._log[1].term == 0
     assert raft_node_2._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
@@ -291,9 +279,7 @@ async def _unittest_raft_log_replication() -> None:
     assert raft_node_2._commit_index == 3
     assert len(raft_node_3._log) == 1 + 3
     assert raft_node_3._log[0].term == 0
-    assert (
-        raft_node_3._log[0].entry.name.value.tobytes().decode("utf-8") == ""
-    )  # index zero entry is empty
+    assert raft_node_3._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
     assert raft_node_3._log[0].entry.value == 0
     assert raft_node_3._log[1].term == 0
     assert raft_node_3._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
@@ -306,9 +292,7 @@ async def _unittest_raft_log_replication() -> None:
     assert raft_node_3._log[3].entry.value == 10
     assert raft_node_3._commit_index == 3
 
-    _logger.info(
-        "================== TEST 3: Replace log entries 2 and 3 with new entries =================="
-    )
+    _logger.info("================== TEST 3: Replace log entries 2 and 3 with new entries ==================")
 
     new_entries = [
         sirius_cyber_corp.LogEntry_1(
@@ -384,9 +368,7 @@ async def _unittest_raft_log_replication() -> None:
     assert raft_node_3._log[3].entry.name.value.tobytes().decode("utf-8") == "top_3"
     assert raft_node_3._log[3].entry.value == 12
 
-    _logger.info(
-        "================== TEST 4: Add an already existing log entry =================="
-    )
+    _logger.info("================== TEST 4: Add an already existing log entry ==================")
 
     new_entry = sirius_cyber_corp.LogEntry_1(
         term=1,
@@ -452,9 +434,7 @@ async def _unittest_raft_log_replication() -> None:
     assert raft_node_3._log[3].entry.name.value.tobytes().decode("utf-8") == "top_3"
     assert raft_node_3._log[3].entry.value == 12
 
-    _logger.info(
-        "================== TEST 5: Add an additional log entry =================="
-    )
+    _logger.info("================== TEST 5: Add an additional log entry ==================")
 
     new_entry = sirius_cyber_corp.LogEntry_1(
         term=1,
@@ -496,9 +476,7 @@ async def _unittest_raft_log_replication() -> None:
     assert raft_node_1._log[4].entry.name.value.tobytes().decode("utf-8") == "top_4"
     assert raft_node_1._log[4].entry.value == 13
 
-    _logger.info(
-        "================== TEST 6: Try to append old log entry (term < currentTerm) =================="
-    )
+    _logger.info("================== TEST 6: Try to append old log entry (term < currentTerm) ==================")
 
     new_entry = sirius_cyber_corp.LogEntry_1(
         term=0,
@@ -712,9 +690,7 @@ async def _unittest_raft_leader_changes() -> None:
     asyncio.create_task(raft_node_3.run())
     asyncio.create_task(raft_node_4.run())
 
-    _logger.info(
-        "================== TEST 1: Append 3 Log Entries to LEADER node 41 =================="
-    )
+    _logger.info("================== TEST 1: Append 3 Log Entries to LEADER node 41 ==================")
 
     # wait for the leader to be elected
     await asyncio.sleep(ELECTION_TIMEOUT + 1)
@@ -774,9 +750,7 @@ async def _unittest_raft_leader_changes() -> None:
     # check if the new entry is replicated in the leader node
     assert len(raft_node_1._log) == 1 + 3
     assert raft_node_1._log[0].term == 0
-    assert (
-        raft_node_1._log[0].entry.name.value.tobytes().decode("utf-8") == ""
-    )  # index zero entry is empty
+    assert raft_node_1._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
     assert raft_node_1._log[0].entry.value == 0
     assert raft_node_1._log[1].term == 1
     assert raft_node_1._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
@@ -792,9 +766,7 @@ async def _unittest_raft_leader_changes() -> None:
     # check if the new entry is replicated in the follower nodes
     assert len(raft_node_2._log) == 1 + 3
     assert raft_node_2._log[0].term == 0
-    assert (
-        raft_node_2._log[0].entry.name.value.tobytes().decode("utf-8") == ""
-    )  # index zero entry is empty
+    assert raft_node_2._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
     assert raft_node_2._log[0].entry.value == 0
     assert raft_node_2._log[1].term == 1
     assert raft_node_2._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
@@ -809,9 +781,7 @@ async def _unittest_raft_leader_changes() -> None:
 
     assert len(raft_node_3._log) == 1 + 3
     assert raft_node_3._log[0].term == 0
-    assert (
-        raft_node_3._log[0].entry.name.value.tobytes().decode("utf-8") == ""
-    )  # index zero entry is empty
+    assert raft_node_3._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
     assert raft_node_3._log[0].entry.value == 0
     assert raft_node_3._log[1].term == 1
     assert raft_node_3._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
@@ -826,9 +796,7 @@ async def _unittest_raft_leader_changes() -> None:
 
     assert len(raft_node_4._log) == 1 + 3
     assert raft_node_4._log[0].term == 0
-    assert (
-        raft_node_4._log[0].entry.name.value.tobytes().decode("utf-8") == ""
-    )  # index zero entry is empty
+    assert raft_node_4._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
     assert raft_node_4._log[0].entry.value == 0
     assert raft_node_4._log[1].term == 1
     assert raft_node_4._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
@@ -843,9 +811,7 @@ async def _unittest_raft_leader_changes() -> None:
 
     await asyncio.sleep(TERM_TIMEOUT + 1)
 
-    _logger.info(
-        "================== TEST 2: Leadership Change to Node 42 and Add New Entry  =================="
-    )
+    _logger.info("================== TEST 2: Leadership Change to Node 42 and Add New Entry  ==================")
 
     # New LEADER => raft_node_2
 
@@ -872,9 +838,7 @@ async def _unittest_raft_leader_changes() -> None:
     # check that all logs are saved from previous LEADER
     assert len(raft_node_2._log) == 1 + 3
     assert raft_node_2._log[0].term == 0
-    assert (
-        raft_node_2._log[0].entry.name.value.tobytes().decode("utf-8") == ""
-    )  # index zero entry is empty
+    assert raft_node_2._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
     assert raft_node_2._log[0].entry.value == 0
     assert raft_node_2._log[1].term == 1
     assert raft_node_2._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
@@ -889,9 +853,7 @@ async def _unittest_raft_leader_changes() -> None:
 
     assert len(raft_node_3._log) == 1 + 3
     assert raft_node_3._log[0].term == 0
-    assert (
-        raft_node_3._log[0].entry.name.value.tobytes().decode("utf-8") == ""
-    )  # index zero entry is empty
+    assert raft_node_3._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
     assert raft_node_3._log[0].entry.value == 0
     assert raft_node_3._log[1].term == 1
     assert raft_node_3._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
@@ -906,9 +868,7 @@ async def _unittest_raft_leader_changes() -> None:
 
     assert len(raft_node_4._log) == 1 + 3
     assert raft_node_4._log[0].term == 0
-    assert (
-        raft_node_4._log[0].entry.name.value.tobytes().decode("utf-8") == ""
-    )  # index zero entry is empty
+    assert raft_node_4._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
     assert raft_node_4._log[0].entry.value == 0
     assert raft_node_4._log[1].term == 1
     assert raft_node_4._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
@@ -1003,9 +963,7 @@ async def _unittest_raft_leader_changes() -> None:
     raft_node_4.close()
     await asyncio.sleep(1)
 
-    _logger.info(
-        "================== TEST 3: Replace Log Entry 3 with a New Entry from LEADER Node 42 =================="
-    )
+    _logger.info("================== TEST 3: Replace Log Entry 3 with a New Entry from LEADER Node 42 ==================")
 
     await asyncio.sleep(TERM_TIMEOUT)
 
@@ -1035,9 +993,7 @@ async def _unittest_raft_leader_changes() -> None:
 
     assert len(raft_node_2._log) == 1 + 3
     assert raft_node_2._log[0].term == 0
-    assert (
-        raft_node_2._log[0].entry.name.value.tobytes().decode("utf-8") == ""
-    )  # index zero entry is empty
+    assert raft_node_2._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
     assert raft_node_2._log[0].entry.value == 0
     assert raft_node_2._log[1].term == 1
     assert raft_node_2._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
@@ -1067,9 +1023,7 @@ async def _unittest_raft_leader_changes() -> None:
 
     assert len(raft_node_3._log) == 1 + 4
     assert raft_node_3._log[0].term == 0
-    assert (
-        raft_node_3._log[0].entry.name.value.tobytes().decode("utf-8") == ""
-    )  # index zero entry is empty
+    assert raft_node_3._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
     assert raft_node_3._log[0].entry.value == 0
     assert raft_node_3._log[1].term == 1
     assert raft_node_3._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"

--- a/tests/raft_log_replication.py
+++ b/tests/raft_log_replication.py
@@ -593,16 +593,13 @@ async def _unittest_raft_log_replication() -> None:
     assert raft_node_1._log[4].entry.name.value.tobytes().decode("utf-8") == "top_4"
     assert raft_node_1._log[4].entry.value == 13
 
-    raft_node_1.close()
-    raft_node_2.close()
-    raft_node_3.close()
-    await asyncio.sleep(1)
 
-# =======================================================================================
-# ========== Test that log replication happens correctly if leadership changes ==========
-# =======================================================================================
 
 """
+=======================================================================================
+========== Test that log replication happens correctly if leadership changes ==========
+=======================================================================================
+
     Initially, all nodes have an empty log entry at index 0 with term 0.
    ____________ 
   | 0          |      Log index
@@ -614,33 +611,32 @@ async def _unittest_raft_log_replication() -> None:
 
    ____________ ____________ ____________ ____________
   | 0          | 1          | 2          | 3          |     Log index
-  | 0          | 4          | 5          | 6          |     Log term
+  | 0          | 1          | 1          | 1          |     Log term
   | empty <= 0 | top_1 <= 7 | top_2 <= 8 | top_3 <= 9 |     Name <= value
   |____________|____________|____________|____________|
 
   Step 2: Leadership Change to Node 42 and Add New Entry 
    ____________ ____________ ____________ ____________ _____________
   | 0          | 1          | 2          | 3          | 4           |     Log index
-  | 0          | 4          | 5          | 6          | 7           |     Log term
+  | 0          | 1          | 1          | 1          | 2           |     Log term
   | empty <= 0 | top_1 <= 7 | top_2 <= 8 | top_3 <= 9 | top_4 <= 17 |     Name <= value
   |____________|____________|____________|____________|_____________|
-
-   Step 3: Replace Log Entry 3 with a New Entry fom LEADER Node 42
+  
+  Step 3: Replace Log Entry 3 with a New Entry from LEADER Node 42
    ____________
   | 3          |     Log index
-  | 7          |     Log term
+  | 2          |     Log term
   | top_3 <= 10|     Name <= value
   |____________|
 
   Result:
    ____________ ____________ ____________ _____________
   | 0          | 1          | 2          | 3           |     Log index
-  | 0          | 4          | 5          | 7           |     Log term
+  | 0          | 1          | 1          | 2           |     Log term
   | empty <= 0 | top_1 <= 7 | top_2 <= 8 | top_3 <= 10 |     Name <= value
   |____________|____________|____________|_____________|
   
 """
-
 
 async def _unittest_raft_leader_changes() -> None:
 
@@ -665,18 +661,26 @@ async def _unittest_raft_leader_changes() -> None:
     os.environ["UAVCAN__NODE__ID"] = "43"
     raft_node_3 = RaftNode()
     raft_node_3.term_timeout = TERM_TIMEOUT
-    raft_node_3.election_timeout = ELECTION_TIMEOUT + 1
+    raft_node_3.election_timeout = ELECTION_TIMEOUT + 2
+    os.environ["UAVCAN__NODE__ID"] = "44"
+    raft_node_4 = RaftNode()
+    raft_node_4.term_timeout = TERM_TIMEOUT
+    raft_node_4.election_timeout = ELECTION_TIMEOUT + 2.1
 
     # make all part of the same cluster
-    cluster = [raft_node_1._node.id, raft_node_2._node.id, raft_node_3._node.id]
+    cluster = [raft_node_1._node.id, raft_node_2._node.id, raft_node_3._node.id, raft_node_4._node.id]
     raft_node_1.add_remote_node(cluster)
     raft_node_2.add_remote_node(cluster)
     raft_node_3.add_remote_node(cluster)
+    raft_node_4.add_remote_node(cluster)
 
     # start all nodes
     asyncio.create_task(raft_node_1.run())
     asyncio.create_task(raft_node_2.run())
     asyncio.create_task(raft_node_3.run())
+    asyncio.create_task(raft_node_4.run())
+
+    _logger.info("================== TEST 1: Append 3 Log Entries to LEADER node 41 ==================")
 
     # wait for the leader to be elected
     await asyncio.sleep(ELECTION_TIMEOUT + 1)
@@ -688,24 +692,25 @@ async def _unittest_raft_leader_changes() -> None:
     assert raft_node_1._voted_for == 41
     assert raft_node_2._voted_for == 41
     assert raft_node_3._voted_for == 41
+    assert raft_node_4._voted_for == 41
 
     new_entries = [
         sirius_cyber_corp.LogEntry_1(
-            term=4,
+            term=1,
             entry=sirius_cyber_corp.Entry_1(
                 name=uavcan.primitive.String_1(value="top_1"),
                 value=7,
             ),
         ),
         sirius_cyber_corp.LogEntry_1(
-            term=5,
+            term=1,
             entry=sirius_cyber_corp.Entry_1(
                 name=uavcan.primitive.String_1(value="top_2"),
                 value=8,
             ),
         ),
         sirius_cyber_corp.LogEntry_1(
-            term=6,
+            term=1,
             entry=sirius_cyber_corp.Entry_1(
                 name=uavcan.primitive.String_1(value="top_3"),
                 value=9,
@@ -737,13 +742,13 @@ async def _unittest_raft_leader_changes() -> None:
     assert raft_node_1._log[0].term == 0
     assert raft_node_1._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
     assert raft_node_1._log[0].entry.value == 0
-    assert raft_node_1._log[1].term == 4
+    assert raft_node_1._log[1].term == 1
     assert raft_node_1._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
     assert raft_node_1._log[1].entry.value == 7
-    assert raft_node_1._log[2].term == 5
+    assert raft_node_1._log[2].term == 1
     assert raft_node_1._log[2].entry.name.value.tobytes().decode("utf-8") == "top_2"
     assert raft_node_1._log[2].entry.value == 8
-    assert raft_node_1._log[3].term == 6
+    assert raft_node_1._log[3].term == 1
     assert raft_node_1._log[3].entry.name.value.tobytes().decode("utf-8") == "top_3"
     assert raft_node_1._log[3].entry.value == 9
     assert raft_node_1._commit_index == 3
@@ -753,13 +758,13 @@ async def _unittest_raft_leader_changes() -> None:
     assert raft_node_2._log[0].term == 0
     assert raft_node_2._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
     assert raft_node_2._log[0].entry.value == 0
-    assert raft_node_2._log[1].term == 4
+    assert raft_node_2._log[1].term == 1
     assert raft_node_2._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
     assert raft_node_2._log[1].entry.value == 7
-    assert raft_node_2._log[2].term == 5
+    assert raft_node_2._log[2].term == 1
     assert raft_node_2._log[2].entry.name.value.tobytes().decode("utf-8") == "top_2"
     assert raft_node_2._log[2].entry.value == 8
-    assert raft_node_2._log[3].term == 6
+    assert raft_node_2._log[3].term == 1
     assert raft_node_2._log[3].entry.name.value.tobytes().decode("utf-8") == "top_3"
     assert raft_node_2._log[3].entry.value == 9
     assert raft_node_2._commit_index == 3
@@ -768,73 +773,68 @@ async def _unittest_raft_leader_changes() -> None:
     assert raft_node_3._log[0].term == 0
     assert raft_node_3._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
     assert raft_node_3._log[0].entry.value == 0
-    assert raft_node_3._log[1].term == 4
+    assert raft_node_3._log[1].term == 1
     assert raft_node_3._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
     assert raft_node_3._log[1].entry.value == 7
-    assert raft_node_3._log[2].term == 5
+    assert raft_node_3._log[2].term == 1
     assert raft_node_3._log[2].entry.name.value.tobytes().decode("utf-8") == "top_2"
     assert raft_node_3._log[2].entry.value == 8
-    assert raft_node_3._log[3].term == 6
+    assert raft_node_3._log[3].term == 1
     assert raft_node_3._log[3].entry.name.value.tobytes().decode("utf-8") == "top_3"
     assert raft_node_3._log[3].entry.value == 9
     assert raft_node_3._commit_index == 3
+
+    assert len(raft_node_4._log) == 1 + 3
+    assert raft_node_4._log[0].term == 0
+    assert raft_node_4._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
+    assert raft_node_4._log[0].entry.value == 0
+    assert raft_node_4._log[1].term == 1
+    assert raft_node_4._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
+    assert raft_node_4._log[1].entry.value == 7
+    assert raft_node_4._log[2].term == 1
+    assert raft_node_4._log[2].entry.name.value.tobytes().decode("utf-8") == "top_2"
+    assert raft_node_4._log[2].entry.value == 8
+    assert raft_node_4._log[3].term == 1
+    assert raft_node_4._log[3].entry.name.value.tobytes().decode("utf-8") == "top_3"
+    assert raft_node_4._log[3].entry.value == 9
+    assert raft_node_4._commit_index == 3
     
     await asyncio.sleep(TERM_TIMEOUT + 1)
-    _logger.info("================== TEST 1: Change LEADER and check logs ==================")
+    
+    _logger.info("================== TEST 2: Leadership Change to Node 42 and Add New Entry  ==================")
 
     # New LEADER => raft_node_2
 
-    raft_node_1.election_timeout = ELECTION_TIMEOUT + 1
-    raft_node_2.election_timeout = ELECTION_TIMEOUT
-    raft_node_3.election_timeout = ELECTION_TIMEOUT + 1
+    await asyncio.sleep(TERM_TIMEOUT)
 
-    raft_node_1._change_state(RaftState.FOLLOWER)
-    raft_node_2._change_state(RaftState.FOLLOWER)
-    raft_node_3._change_state(RaftState.FOLLOWER)
-    raft_node_1._voted_for = None
+    raft_node_1.close() # Simulation of the disappearance of a leader from a cluster
 
-
-    await asyncio.sleep(2*ELECTION_TIMEOUT + 1)
-
-    assert raft_node_1._state == RaftState.FOLLOWER
-    assert raft_node_1._term == 20, "received heartbeat from LEADER"
-    assert raft_node_1._voted_for == 42
+    await asyncio.sleep(ELECTION_TIMEOUT + 9*TERM_TIMEOUT) # Nine terms are needed for complete replication of logs from the leader to the followers.
 
     assert raft_node_2._state == RaftState.LEADER
-    assert raft_node_2._term == 20
+    assert raft_node_2._term == 2
     assert raft_node_2._voted_for == 42
 
+    assert raft_node_4._state == RaftState.FOLLOWER
+    assert raft_node_4._term == 2, "received heartbeat from LEADER"
+    assert raft_node_4._voted_for == 42 
+
     assert raft_node_3._state == RaftState.FOLLOWER
-    assert raft_node_3._term == 20, "received heartbeat from LEADER"
+    assert raft_node_3._term == 2, "received heartbeat from LEADER"
     assert raft_node_3._voted_for == 42
 
     # check that all logs are saved from previous LEADER
-    assert len(raft_node_1._log) == 1 + 3
-    assert raft_node_1._log[0].term == 0
-    assert raft_node_1._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
-    assert raft_node_1._log[0].entry.value == 0
-    assert raft_node_1._log[1].term == 4
-    assert raft_node_1._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
-    assert raft_node_1._log[1].entry.value == 7
-    assert raft_node_1._log[2].term == 5
-    assert raft_node_1._log[2].entry.name.value.tobytes().decode("utf-8") == "top_2"
-    assert raft_node_1._log[2].entry.value == 8
-    assert raft_node_1._log[3].term == 6
-    assert raft_node_1._log[3].entry.name.value.tobytes().decode("utf-8") == "top_3"
-    assert raft_node_1._log[3].entry.value == 9
-    assert raft_node_1._commit_index == 3
-
     assert len(raft_node_2._log) == 1 + 3
     assert raft_node_2._log[0].term == 0
     assert raft_node_2._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
     assert raft_node_2._log[0].entry.value == 0
-    assert raft_node_2._log[1].term == 4
+    assert raft_node_2._log[1].term == 1
     assert raft_node_2._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
     assert raft_node_2._log[1].entry.value == 7
-    assert raft_node_2._log[2].term == 5
+    assert raft_node_2._log[2].term == 1
     assert raft_node_2._log[2].entry.name.value.tobytes().decode("utf-8") == "top_2"
     assert raft_node_2._log[2].entry.value == 8
-    assert raft_node_2._log[3].term == 6
+    assert raft_node_2._log[3].term == 1
     assert raft_node_2._log[3].entry.name.value.tobytes().decode("utf-8") == "top_3"
     assert raft_node_2._log[3].entry.value == 9
     assert raft_node_2._commit_index == 3
@@ -843,21 +843,34 @@ async def _unittest_raft_leader_changes() -> None:
     assert raft_node_3._log[0].term == 0
     assert raft_node_3._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
     assert raft_node_3._log[0].entry.value == 0
-    assert raft_node_3._log[1].term == 4
+    assert raft_node_3._log[1].term == 1
     assert raft_node_3._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
     assert raft_node_3._log[1].entry.value == 7
-    assert raft_node_3._log[2].term == 5
+    assert raft_node_3._log[2].term == 1
     assert raft_node_3._log[2].entry.name.value.tobytes().decode("utf-8") == "top_2"
     assert raft_node_3._log[2].entry.value == 8
-    assert raft_node_3._log[3].term == 6
+    assert raft_node_3._log[3].term == 1
     assert raft_node_3._log[3].entry.name.value.tobytes().decode("utf-8") == "top_3"
     assert raft_node_3._log[3].entry.value == 9
     assert raft_node_3._commit_index == 3
 
-    _logger.info("================== TEST 2: Append new log entry fron another LEADER ==================")
+    assert len(raft_node_4._log) == 1 + 3
+    assert raft_node_4._log[0].term == 0
+    assert raft_node_4._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
+    assert raft_node_4._log[0].entry.value == 0
+    assert raft_node_4._log[1].term == 1
+    assert raft_node_4._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
+    assert raft_node_4._log[1].entry.value == 7
+    assert raft_node_4._log[2].term == 1
+    assert raft_node_4._log[2].entry.name.value.tobytes().decode("utf-8") == "top_2"
+    assert raft_node_4._log[2].entry.value == 8
+    assert raft_node_4._log[3].term == 1
+    assert raft_node_4._log[3].entry.name.value.tobytes().decode("utf-8") == "top_3"
+    assert raft_node_4._log[3].entry.value == 9
+    assert raft_node_4._commit_index == 3
 
     new_entry = sirius_cyber_corp.LogEntry_1(
-        term=7,
+        term=raft_node_2._term,
         entry=sirius_cyber_corp.Entry_1(
             name=uavcan.primitive.String_1(value="top_4"),
             value=13,
@@ -881,71 +894,78 @@ async def _unittest_raft_leader_changes() -> None:
     assert response.success == True
 
     await asyncio.sleep(TERM_TIMEOUT + 1)
-
+    
     assert len(raft_node_2._log) == 1 + 4
     assert raft_node_2._log[0].term == 0
     assert raft_node_2._log[0].entry.value == 0
-    assert raft_node_2._log[1].term == 4
+    assert raft_node_2._log[1].term == 1
     assert raft_node_2._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
     assert raft_node_2._log[1].entry.value == 7
-    assert raft_node_2._log[2].term == 5
+    assert raft_node_2._log[2].term == 1
     assert raft_node_2._log[2].entry.name.value.tobytes().decode("utf-8") == "top_2"
     assert raft_node_2._log[2].entry.value == 8
-    assert raft_node_2._log[3].term == 6
+    assert raft_node_2._log[3].term == 1
     assert raft_node_2._log[3].entry.name.value.tobytes().decode("utf-8") == "top_3"
     assert raft_node_2._log[3].entry.value == 9
-    assert raft_node_2._log[4].term == 7
+    assert raft_node_2._log[4].term == 2
     assert raft_node_2._log[4].entry.name.value.tobytes().decode("utf-8") == "top_4"
     assert raft_node_2._log[4].entry.value == 13
     assert raft_node_2._commit_index == 4
 
-    assert len(raft_node_1._log) == 1 + 4
-    assert raft_node_1._log[0].term == 0
-    assert raft_node_1._log[0].entry.value == 0
-    assert raft_node_1._log[1].term == 4
-    assert raft_node_1._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
-    assert raft_node_1._log[1].entry.value == 7
-    assert raft_node_1._log[2].term == 5
-    assert raft_node_1._log[2].entry.name.value.tobytes().decode("utf-8") == "top_2"
-    assert raft_node_1._log[2].entry.value == 8
-    assert raft_node_1._log[3].term == 6
-    assert raft_node_1._log[3].entry.name.value.tobytes().decode("utf-8") == "top_3"
-    assert raft_node_1._log[3].entry.value == 9
-    assert raft_node_1._log[4].term == 7
-    assert raft_node_1._log[4].entry.name.value.tobytes().decode("utf-8") == "top_4"
-    assert raft_node_1._log[4].entry.value == 13
-    assert raft_node_1._commit_index == 4
-    
     assert len(raft_node_3._log) == 1 + 4
     assert raft_node_3._log[0].term == 0
     assert raft_node_3._log[0].entry.value == 0
-    assert raft_node_3._log[1].term == 4
+    assert raft_node_3._log[1].term == 1
     assert raft_node_3._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
     assert raft_node_3._log[1].entry.value == 7
-    assert raft_node_3._log[2].term == 5
+    assert raft_node_3._log[2].term == 1
     assert raft_node_3._log[2].entry.name.value.tobytes().decode("utf-8") == "top_2"
     assert raft_node_3._log[2].entry.value == 8
-    assert raft_node_3._log[3].term == 6
+    assert raft_node_3._log[3].term == 1
     assert raft_node_3._log[3].entry.name.value.tobytes().decode("utf-8") == "top_3"
     assert raft_node_3._log[3].entry.value == 9
-    assert raft_node_3._log[4].term == 7
+    assert raft_node_3._log[4].term == 2
     assert raft_node_3._log[4].entry.name.value.tobytes().decode("utf-8") == "top_4"
     assert raft_node_3._log[4].entry.value == 13
     assert raft_node_3._commit_index == 4
 
-    _logger.info("================== TEST 3: Replace log entries 1 and 4 with new entries from another LEADER ==================")
+    assert len(raft_node_4._log) == 1 + 4
+    assert raft_node_4._log[0].term == 0
+    assert raft_node_4._log[0].entry.value == 0
+    assert raft_node_4._log[1].term == 1
+    assert raft_node_4._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
+    assert raft_node_4._log[1].entry.value == 7
+    assert raft_node_4._log[2].term == 1
+    assert raft_node_4._log[2].entry.name.value.tobytes().decode("utf-8") == "top_2"
+    assert raft_node_4._log[2].entry.value == 8
+    assert raft_node_4._log[3].term == 1
+    assert raft_node_4._log[3].entry.name.value.tobytes().decode("utf-8") == "top_3"
+    assert raft_node_4._log[3].entry.value == 9
+    assert raft_node_4._log[4].term == 2
+    assert raft_node_4._log[4].entry.name.value.tobytes().decode("utf-8") == "top_4"
+    assert raft_node_4._log[4].entry.value == 13
+    assert raft_node_4._commit_index == 4
+
+    raft_node_2.close()
+    raft_node_3.close()
+    raft_node_4.close()
+    await asyncio.sleep(1)
+    
+    _logger.info("================== TEST 3: Replace Log Entry 3 with a New Entry from LEADER Node 42 ==================")
+
+    await asyncio.sleep(TERM_TIMEOUT)
 
     new_entry = sirius_cyber_corp.LogEntry_1(
-        term=7,
+        term=2,
         entry=sirius_cyber_corp.Entry_1(
             name=uavcan.primitive.String_1(value="top_3"),
             value=10,
         ),
     )
     request = sirius_cyber_corp.AppendEntries_1.Request(
-        term=raft_node_1._term,
+        term=raft_node_2._term,
         prev_log_index=2,  # index of top_2
-        prev_log_term=raft_node_1._log[2].term,
+        prev_log_term=raft_node_2._log[2].term,
         log_entry=new_entry,
     )
     metadata = pycyphal.presentation.ServiceRequestMetadata(
@@ -963,50 +983,48 @@ async def _unittest_raft_leader_changes() -> None:
     assert raft_node_2._log[0].term == 0
     assert raft_node_2._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
     assert raft_node_2._log[0].entry.value == 0
-    assert raft_node_2._log[1].term == 4
+    assert raft_node_2._log[1].term == 1
     assert raft_node_2._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
     assert raft_node_2._log[1].entry.value == 7
-    assert raft_node_2._log[2].term == 5
+    assert raft_node_2._log[2].term == 1
     assert raft_node_2._log[2].entry.name.value.tobytes().decode("utf-8") == "top_2"
     assert raft_node_2._log[2].entry.value == 8
-    assert raft_node_2._log[3].term == 7
+    assert raft_node_2._log[3].term == 2
     assert raft_node_2._log[3].entry.name.value.tobytes().decode("utf-8") == "top_3"
     assert raft_node_2._log[3].entry.value == 10
     assert raft_node_2._commit_index == 3
 
     # check if the new entry is replicated in the follower nodes
-    assert len(raft_node_1._log) == 1 + 3
-    assert raft_node_1._log[0].term == 0
-    assert raft_node_1._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
-    assert raft_node_1._log[0].entry.value == 0
-    assert raft_node_1._log[1].term == 4
-    assert raft_node_1._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
-    assert raft_node_1._log[1].entry.value == 7
-    assert raft_node_1._log[2].term == 5
-    assert raft_node_1._log[2].entry.name.value.tobytes().decode("utf-8") == "top_2"
-    assert raft_node_1._log[2].entry.value == 8
-    assert raft_node_1._log[3].term == 7
-    assert raft_node_1._log[3].entry.name.value.tobytes().decode("utf-8") == "top_3"
-    assert raft_node_1._log[3].entry.value == 10
-    assert raft_node_1._commit_index == 3
+    assert len(raft_node_4._log) == 1 + 4
+    assert raft_node_4._log[0].term == 0
+    assert raft_node_4._log[0].entry.value == 0
+    assert raft_node_4._log[1].term == 1
+    assert raft_node_4._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
+    assert raft_node_4._log[1].entry.value == 7
+    assert raft_node_4._log[2].term == 1
+    assert raft_node_4._log[2].entry.name.value.tobytes().decode("utf-8") == "top_2"
+    assert raft_node_4._log[2].entry.value == 8
+    assert raft_node_4._log[3].term == 1
+    assert raft_node_4._log[3].entry.name.value.tobytes().decode("utf-8") == "top_3"
+    assert raft_node_4._log[3].entry.value == 9
+    assert raft_node_4._commit_index == 4
 
-    assert len(raft_node_3._log) == 1 + 3
+    assert len(raft_node_3._log) == 1 + 4
     assert raft_node_3._log[0].term == 0
     assert raft_node_3._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
     assert raft_node_3._log[0].entry.value == 0
-    assert raft_node_3._log[1].term == 4
+    assert raft_node_3._log[1].term == 1
     assert raft_node_3._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
     assert raft_node_3._log[1].entry.value == 7
-    assert raft_node_3._log[2].term == 5
+    assert raft_node_3._log[2].term == 1
     assert raft_node_3._log[2].entry.name.value.tobytes().decode("utf-8") == "top_2"
     assert raft_node_3._log[2].entry.value == 8
-    assert raft_node_3._log[3].term == 7
+    assert raft_node_3._log[3].term == 1
     assert raft_node_3._log[3].entry.name.value.tobytes().decode("utf-8") == "top_3"
-    assert raft_node_3._log[3].entry.value == 10
-    assert raft_node_3._commit_index == 3
+    assert raft_node_3._log[3].entry.value == 9
+    assert raft_node_3._commit_index == 4
 
-    
-    raft_node_1.close()
     raft_node_2.close()
     raft_node_3.close()
+    raft_node_4.close()
     await asyncio.sleep(1)

--- a/tests/raft_log_replication.py
+++ b/tests/raft_log_replication.py
@@ -593,6 +593,10 @@ async def _unittest_raft_log_replication() -> None:
     assert raft_node_1._log[4].entry.name.value.tobytes().decode("utf-8") == "top_4"
     assert raft_node_1._log[4].entry.value == 13
 
+    raft_node_1.close()
+    raft_node_2.close()
+    raft_node_3.close()
+    await asyncio.sleep(1)
 
 
 """

--- a/tests/raft_log_replication.py
+++ b/tests/raft_log_replication.py
@@ -313,7 +313,7 @@ async def _unittest_raft_log_replication() -> None:
 
     for index, new_entry in enumerate(new_entries):
         request = sirius_cyber_corp.AppendEntries_1.Request(
-            term=1,
+            term=raft_node_1._term,
             prev_log_index=index + 1,  # index: 1, 2
             prev_log_term=raft_node_1._log[index + 1].term,
             log_entry=new_entry,
@@ -378,7 +378,7 @@ async def _unittest_raft_log_replication() -> None:
         ),
     )
     request = sirius_cyber_corp.AppendEntries_1.Request(
-        term=1,
+        term=raft_node_1._term,
         prev_log_index=2,  # index of top_2
         prev_log_term=raft_node_1._log[2].term,
         log_entry=new_entry,

--- a/tests/raft_log_replication.py
+++ b/tests/raft_log_replication.py
@@ -12,7 +12,7 @@ import uavcan
 
 # Add parent directory to Python path
 # Get the absolute path of the parent directory
-parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 # Add the parent directory to the Python path
 sys.path.append(parent_dir)
 # This can be removed if setting PYTHONPATH (export PYTHONPATH=cyraft)
@@ -178,7 +178,9 @@ async def _unittest_raft_log_replication() -> None:
     # check if the new entry is replicated in the leader node
     assert len(raft_node_1._log) == 1 + 3
     assert raft_node_1._log[0].term == 0
-    assert raft_node_1._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
+    assert (
+        raft_node_1._log[0].entry.name.value.tobytes().decode("utf-8") == ""
+    )  # index zero entry is empty
     assert raft_node_1._log[0].entry.value == 0
     assert raft_node_1._log[1].term == 0
     assert raft_node_1._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
@@ -194,7 +196,9 @@ async def _unittest_raft_log_replication() -> None:
     # check if the new entry is replicated in the follower nodes
     assert len(raft_node_2._log) == 1 + 3
     assert raft_node_2._log[0].term == 0
-    assert raft_node_2._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
+    assert (
+        raft_node_2._log[0].entry.name.value.tobytes().decode("utf-8") == ""
+    )  # index zero entry is empty
     assert raft_node_2._log[0].entry.value == 0
     assert raft_node_2._log[1].term == 0
     assert raft_node_2._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
@@ -208,7 +212,9 @@ async def _unittest_raft_log_replication() -> None:
     assert raft_node_2._commit_index == 3
     assert len(raft_node_3._log) == 1 + 3
     assert raft_node_3._log[0].term == 0
-    assert raft_node_3._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
+    assert (
+        raft_node_3._log[0].entry.name.value.tobytes().decode("utf-8") == ""
+    )  # index zero entry is empty
     assert raft_node_3._log[0].entry.value == 0
     assert raft_node_3._log[1].term == 0
     assert raft_node_3._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
@@ -221,7 +227,9 @@ async def _unittest_raft_log_replication() -> None:
     assert raft_node_3._log[3].entry.value == 9
     assert raft_node_3._commit_index == 3
 
-    _logger.info("================== TEST 2: Replace log entry 3 with a new entry ==================")
+    _logger.info(
+        "================== TEST 2: Replace log entry 3 with a new entry =================="
+    )
 
     new_entry = sirius_cyber_corp.LogEntry_1(
         term=1,
@@ -249,7 +257,9 @@ async def _unittest_raft_log_replication() -> None:
 
     assert len(raft_node_1._log) == 1 + 3
     assert raft_node_1._log[0].term == 0
-    assert raft_node_1._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
+    assert (
+        raft_node_1._log[0].entry.name.value.tobytes().decode("utf-8") == ""
+    )  # index zero entry is empty
     assert raft_node_1._log[0].entry.value == 0
     assert raft_node_1._log[1].term == 0
     assert raft_node_1._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
@@ -265,7 +275,9 @@ async def _unittest_raft_log_replication() -> None:
     # check if the new entry is replicated in the follower nodes
     assert len(raft_node_2._log) == 1 + 3
     assert raft_node_2._log[0].term == 0
-    assert raft_node_2._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
+    assert (
+        raft_node_2._log[0].entry.name.value.tobytes().decode("utf-8") == ""
+    )  # index zero entry is empty
     assert raft_node_2._log[0].entry.value == 0
     assert raft_node_2._log[1].term == 0
     assert raft_node_2._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
@@ -279,7 +291,9 @@ async def _unittest_raft_log_replication() -> None:
     assert raft_node_2._commit_index == 3
     assert len(raft_node_3._log) == 1 + 3
     assert raft_node_3._log[0].term == 0
-    assert raft_node_3._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
+    assert (
+        raft_node_3._log[0].entry.name.value.tobytes().decode("utf-8") == ""
+    )  # index zero entry is empty
     assert raft_node_3._log[0].entry.value == 0
     assert raft_node_3._log[1].term == 0
     assert raft_node_3._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
@@ -292,7 +306,9 @@ async def _unittest_raft_log_replication() -> None:
     assert raft_node_3._log[3].entry.value == 10
     assert raft_node_3._commit_index == 3
 
-    _logger.info("================== TEST 3: Replace log entries 2 and 3 with new entries ==================")
+    _logger.info(
+        "================== TEST 3: Replace log entries 2 and 3 with new entries =================="
+    )
 
     new_entries = [
         sirius_cyber_corp.LogEntry_1(
@@ -368,7 +384,9 @@ async def _unittest_raft_log_replication() -> None:
     assert raft_node_3._log[3].entry.name.value.tobytes().decode("utf-8") == "top_3"
     assert raft_node_3._log[3].entry.value == 12
 
-    _logger.info("================== TEST 4: Add an already existing log entry ==================")
+    _logger.info(
+        "================== TEST 4: Add an already existing log entry =================="
+    )
 
     new_entry = sirius_cyber_corp.LogEntry_1(
         term=1,
@@ -434,7 +452,9 @@ async def _unittest_raft_log_replication() -> None:
     assert raft_node_3._log[3].entry.name.value.tobytes().decode("utf-8") == "top_3"
     assert raft_node_3._log[3].entry.value == 12
 
-    _logger.info("================== TEST 5: Add an additional log entry ==================")
+    _logger.info(
+        "================== TEST 5: Add an additional log entry =================="
+    )
 
     new_entry = sirius_cyber_corp.LogEntry_1(
         term=1,
@@ -476,7 +496,9 @@ async def _unittest_raft_log_replication() -> None:
     assert raft_node_1._log[4].entry.name.value.tobytes().decode("utf-8") == "top_4"
     assert raft_node_1._log[4].entry.value == 13
 
-    _logger.info("================== TEST 6: Try to append old log entry (term < currentTerm) ==================")
+    _logger.info(
+        "================== TEST 6: Try to append old log entry (term < currentTerm) =================="
+    )
 
     new_entry = sirius_cyber_corp.LogEntry_1(
         term=0,
@@ -642,6 +664,7 @@ async def _unittest_raft_log_replication() -> None:
   
 """
 
+
 async def _unittest_raft_leader_changes() -> None:
 
     logging.root.setLevel(logging.INFO)
@@ -672,7 +695,12 @@ async def _unittest_raft_leader_changes() -> None:
     raft_node_4.election_timeout = ELECTION_TIMEOUT + 2.1
 
     # make all part of the same cluster
-    cluster = [raft_node_1._node.id, raft_node_2._node.id, raft_node_3._node.id, raft_node_4._node.id]
+    cluster = [
+        raft_node_1._node.id,
+        raft_node_2._node.id,
+        raft_node_3._node.id,
+        raft_node_4._node.id,
+    ]
     raft_node_1.add_remote_node(cluster)
     raft_node_2.add_remote_node(cluster)
     raft_node_3.add_remote_node(cluster)
@@ -684,7 +712,9 @@ async def _unittest_raft_leader_changes() -> None:
     asyncio.create_task(raft_node_3.run())
     asyncio.create_task(raft_node_4.run())
 
-    _logger.info("================== TEST 1: Append 3 Log Entries to LEADER node 41 ==================")
+    _logger.info(
+        "================== TEST 1: Append 3 Log Entries to LEADER node 41 =================="
+    )
 
     # wait for the leader to be elected
     await asyncio.sleep(ELECTION_TIMEOUT + 1)
@@ -744,7 +774,9 @@ async def _unittest_raft_leader_changes() -> None:
     # check if the new entry is replicated in the leader node
     assert len(raft_node_1._log) == 1 + 3
     assert raft_node_1._log[0].term == 0
-    assert raft_node_1._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
+    assert (
+        raft_node_1._log[0].entry.name.value.tobytes().decode("utf-8") == ""
+    )  # index zero entry is empty
     assert raft_node_1._log[0].entry.value == 0
     assert raft_node_1._log[1].term == 1
     assert raft_node_1._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
@@ -760,7 +792,9 @@ async def _unittest_raft_leader_changes() -> None:
     # check if the new entry is replicated in the follower nodes
     assert len(raft_node_2._log) == 1 + 3
     assert raft_node_2._log[0].term == 0
-    assert raft_node_2._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
+    assert (
+        raft_node_2._log[0].entry.name.value.tobytes().decode("utf-8") == ""
+    )  # index zero entry is empty
     assert raft_node_2._log[0].entry.value == 0
     assert raft_node_2._log[1].term == 1
     assert raft_node_2._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
@@ -775,7 +809,9 @@ async def _unittest_raft_leader_changes() -> None:
 
     assert len(raft_node_3._log) == 1 + 3
     assert raft_node_3._log[0].term == 0
-    assert raft_node_3._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
+    assert (
+        raft_node_3._log[0].entry.name.value.tobytes().decode("utf-8") == ""
+    )  # index zero entry is empty
     assert raft_node_3._log[0].entry.value == 0
     assert raft_node_3._log[1].term == 1
     assert raft_node_3._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
@@ -790,7 +826,9 @@ async def _unittest_raft_leader_changes() -> None:
 
     assert len(raft_node_4._log) == 1 + 3
     assert raft_node_4._log[0].term == 0
-    assert raft_node_4._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
+    assert (
+        raft_node_4._log[0].entry.name.value.tobytes().decode("utf-8") == ""
+    )  # index zero entry is empty
     assert raft_node_4._log[0].entry.value == 0
     assert raft_node_4._log[1].term == 1
     assert raft_node_4._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
@@ -802,18 +840,22 @@ async def _unittest_raft_leader_changes() -> None:
     assert raft_node_4._log[3].entry.name.value.tobytes().decode("utf-8") == "top_3"
     assert raft_node_4._log[3].entry.value == 9
     assert raft_node_4._commit_index == 3
-    
+
     await asyncio.sleep(TERM_TIMEOUT + 1)
-    
-    _logger.info("================== TEST 2: Leadership Change to Node 42 and Add New Entry  ==================")
+
+    _logger.info(
+        "================== TEST 2: Leadership Change to Node 42 and Add New Entry  =================="
+    )
 
     # New LEADER => raft_node_2
 
     await asyncio.sleep(TERM_TIMEOUT)
 
-    raft_node_1.close() # Simulation of the disappearance of a leader from a cluster
+    raft_node_1.close()  # Simulation of the disappearance of a leader from a cluster
 
-    await asyncio.sleep(ELECTION_TIMEOUT + 9*TERM_TIMEOUT) # Nine terms are needed for complete replication of logs from the leader to the followers.
+    await asyncio.sleep(
+        ELECTION_TIMEOUT + 9 * TERM_TIMEOUT
+    )  # Nine terms are needed for complete replication of logs from the leader to the followers.
 
     assert raft_node_2._state == RaftState.LEADER
     assert raft_node_2._term == 2
@@ -821,7 +863,7 @@ async def _unittest_raft_leader_changes() -> None:
 
     assert raft_node_4._state == RaftState.FOLLOWER
     assert raft_node_4._term == 2, "received heartbeat from LEADER"
-    assert raft_node_4._voted_for == 42 
+    assert raft_node_4._voted_for == 42
 
     assert raft_node_3._state == RaftState.FOLLOWER
     assert raft_node_3._term == 2, "received heartbeat from LEADER"
@@ -830,7 +872,9 @@ async def _unittest_raft_leader_changes() -> None:
     # check that all logs are saved from previous LEADER
     assert len(raft_node_2._log) == 1 + 3
     assert raft_node_2._log[0].term == 0
-    assert raft_node_2._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
+    assert (
+        raft_node_2._log[0].entry.name.value.tobytes().decode("utf-8") == ""
+    )  # index zero entry is empty
     assert raft_node_2._log[0].entry.value == 0
     assert raft_node_2._log[1].term == 1
     assert raft_node_2._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
@@ -845,7 +889,9 @@ async def _unittest_raft_leader_changes() -> None:
 
     assert len(raft_node_3._log) == 1 + 3
     assert raft_node_3._log[0].term == 0
-    assert raft_node_3._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
+    assert (
+        raft_node_3._log[0].entry.name.value.tobytes().decode("utf-8") == ""
+    )  # index zero entry is empty
     assert raft_node_3._log[0].entry.value == 0
     assert raft_node_3._log[1].term == 1
     assert raft_node_3._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
@@ -860,7 +906,9 @@ async def _unittest_raft_leader_changes() -> None:
 
     assert len(raft_node_4._log) == 1 + 3
     assert raft_node_4._log[0].term == 0
-    assert raft_node_4._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
+    assert (
+        raft_node_4._log[0].entry.name.value.tobytes().decode("utf-8") == ""
+    )  # index zero entry is empty
     assert raft_node_4._log[0].entry.value == 0
     assert raft_node_4._log[1].term == 1
     assert raft_node_4._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
@@ -898,7 +946,7 @@ async def _unittest_raft_leader_changes() -> None:
     assert response.success == True
 
     await asyncio.sleep(TERM_TIMEOUT + 1)
-    
+
     assert len(raft_node_2._log) == 1 + 4
     assert raft_node_2._log[0].term == 0
     assert raft_node_2._log[0].entry.value == 0
@@ -954,8 +1002,10 @@ async def _unittest_raft_leader_changes() -> None:
     raft_node_3.close()
     raft_node_4.close()
     await asyncio.sleep(1)
-    
-    _logger.info("================== TEST 3: Replace Log Entry 3 with a New Entry from LEADER Node 42 ==================")
+
+    _logger.info(
+        "================== TEST 3: Replace Log Entry 3 with a New Entry from LEADER Node 42 =================="
+    )
 
     await asyncio.sleep(TERM_TIMEOUT)
 
@@ -985,7 +1035,9 @@ async def _unittest_raft_leader_changes() -> None:
 
     assert len(raft_node_2._log) == 1 + 3
     assert raft_node_2._log[0].term == 0
-    assert raft_node_2._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
+    assert (
+        raft_node_2._log[0].entry.name.value.tobytes().decode("utf-8") == ""
+    )  # index zero entry is empty
     assert raft_node_2._log[0].entry.value == 0
     assert raft_node_2._log[1].term == 1
     assert raft_node_2._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
@@ -1015,7 +1067,9 @@ async def _unittest_raft_leader_changes() -> None:
 
     assert len(raft_node_3._log) == 1 + 4
     assert raft_node_3._log[0].term == 0
-    assert raft_node_3._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
+    assert (
+        raft_node_3._log[0].entry.name.value.tobytes().decode("utf-8") == ""
+    )  # index zero entry is empty
     assert raft_node_3._log[0].entry.value == 0
     assert raft_node_3._log[1].term == 1
     assert raft_node_3._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"

--- a/tests/raft_log_replication.py
+++ b/tests/raft_log_replication.py
@@ -602,6 +602,44 @@ async def _unittest_raft_log_replication() -> None:
 # ========== Test that log replication happens correctly if leadership changes ==========
 # =======================================================================================
 
+"""
+    Initially, all nodes have an empty log entry at index 0 with term 0.
+   ____________ 
+  | 0          |      Log index
+  | 0          |      Log term
+  | empty <= 0 |      Name <= value
+  |____________|
+
+    Step 1: Append 3 Log Entries to LEADER node 41
+
+   ____________ ____________ ____________ ____________
+  | 0          | 1          | 2          | 3          |     Log index
+  | 0          | 4          | 5          | 6          |     Log term
+  | empty <= 0 | top_1 <= 7 | top_2 <= 8 | top_3 <= 9 |     Name <= value
+  |____________|____________|____________|____________|
+
+  Step 2: Leadership Change to Node 42 and Add New Entry 
+   ____________ ____________ ____________ ____________ _____________
+  | 0          | 1          | 2          | 3          | 4           |     Log index
+  | 0          | 4          | 5          | 6          | 7           |     Log term
+  | empty <= 0 | top_1 <= 7 | top_2 <= 8 | top_3 <= 9 | top_4 <= 17 |     Name <= value
+  |____________|____________|____________|____________|_____________|
+
+   Step 3: Replace Log Entry 3 with a New Entry fom LEADER Node 42
+   ____________
+  | 3          |     Log index
+  | 7          |     Log term
+  | top_3 <= 10|     Name <= value
+  |____________|
+
+  Result:
+   ____________ ____________ ____________ _____________
+  | 0          | 1          | 2          | 3           |     Log index
+  | 0          | 4          | 5          | 7           |     Log term
+  | empty <= 0 | top_1 <= 7 | top_2 <= 8 | top_3 <= 10 |     Name <= value
+  |____________|____________|____________|_____________|
+  
+"""
 
 
 async def _unittest_raft_leader_changes() -> None:
@@ -683,14 +721,14 @@ async def _unittest_raft_leader_changes() -> None:
             log_entry=new_entry,
         )
         metadata = pycyphal.presentation.ServiceRequestMetadata(
-            client_node_id=42,
+            client_node_id=41,
             timestamp=time.time(),
             priority=0,
             transfer_id=0,
         )
         response = await raft_node_1._serve_append_entries(request, metadata)
         assert response.success == True
-    _logger.info("=========Start=========")
+
     # wait for the request to be replicated
     await asyncio.sleep(TERM_TIMEOUT + 1)
 
@@ -742,7 +780,7 @@ async def _unittest_raft_leader_changes() -> None:
     assert raft_node_3._commit_index == 3
     
     await asyncio.sleep(TERM_TIMEOUT + 1)
-    _logger.info("================== TEST 1: change LEADER and check logs ==================")
+    _logger.info("================== TEST 1: Change LEADER and check logs ==================")
 
     # New LEADER => raft_node_2
 
@@ -756,18 +794,18 @@ async def _unittest_raft_leader_changes() -> None:
     raft_node_1._voted_for = None
 
 
-    await asyncio.sleep(ELECTION_TIMEOUT + 1)
+    await asyncio.sleep(2*ELECTION_TIMEOUT + 1)
 
     assert raft_node_1._state == RaftState.FOLLOWER
-    assert raft_node_1._term == 1, "received heartbeat from LEADER"
+    assert raft_node_1._term == 20, "received heartbeat from LEADER"
     assert raft_node_1._voted_for == 42
 
     assert raft_node_2._state == RaftState.LEADER
-    assert raft_node_2._term == 1
+    assert raft_node_2._term == 20
     assert raft_node_2._voted_for == 42
 
     assert raft_node_3._state == RaftState.FOLLOWER
-    assert raft_node_3._term == 1, "received heartbeat from LEADER"
+    assert raft_node_3._term == 20, "received heartbeat from LEADER"
     assert raft_node_3._voted_for == 42
 
     # check that all logs are saved from previous LEADER
@@ -816,7 +854,7 @@ async def _unittest_raft_leader_changes() -> None:
     assert raft_node_3._log[3].entry.value == 9
     assert raft_node_3._commit_index == 3
 
-    _logger.info("================== TEST 2: append new log entry fron another LEADER ==================")
+    _logger.info("================== TEST 2: Append new log entry fron another LEADER ==================")
 
     new_entry = sirius_cyber_corp.LogEntry_1(
         term=7,
@@ -839,7 +877,7 @@ async def _unittest_raft_leader_changes() -> None:
     )
 
     response = await raft_node_2._serve_append_entries(request, metadata)
-    _logger.info("=========END=========")
+
     assert response.success == True
 
     await asyncio.sleep(TERM_TIMEOUT + 1)
@@ -894,6 +932,78 @@ async def _unittest_raft_leader_changes() -> None:
     assert raft_node_3._log[4].entry.name.value.tobytes().decode("utf-8") == "top_4"
     assert raft_node_3._log[4].entry.value == 13
     assert raft_node_3._commit_index == 4
+
+    _logger.info("================== TEST 3: Replace log entries 1 and 4 with new entries from another LEADER ==================")
+
+    new_entry = sirius_cyber_corp.LogEntry_1(
+        term=7,
+        entry=sirius_cyber_corp.Entry_1(
+            name=uavcan.primitive.String_1(value="top_3"),
+            value=10,
+        ),
+    )
+    request = sirius_cyber_corp.AppendEntries_1.Request(
+        term=raft_node_1._term,
+        prev_log_index=2,  # index of top_2
+        prev_log_term=raft_node_1._log[2].term,
+        log_entry=new_entry,
+    )
+    metadata = pycyphal.presentation.ServiceRequestMetadata(
+        client_node_id=42,
+        timestamp=time.time(),
+        priority=0,
+        transfer_id=0,
+    )
+    response = await raft_node_2._serve_append_entries(request, metadata)
+    assert response.success == True
+
+    await asyncio.sleep(TERM_TIMEOUT + 1)
+
+    assert len(raft_node_2._log) == 1 + 3
+    assert raft_node_2._log[0].term == 0
+    assert raft_node_2._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
+    assert raft_node_2._log[0].entry.value == 0
+    assert raft_node_2._log[1].term == 4
+    assert raft_node_2._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
+    assert raft_node_2._log[1].entry.value == 7
+    assert raft_node_2._log[2].term == 5
+    assert raft_node_2._log[2].entry.name.value.tobytes().decode("utf-8") == "top_2"
+    assert raft_node_2._log[2].entry.value == 8
+    assert raft_node_2._log[3].term == 7
+    assert raft_node_2._log[3].entry.name.value.tobytes().decode("utf-8") == "top_3"
+    assert raft_node_2._log[3].entry.value == 10
+    assert raft_node_2._commit_index == 3
+
+    # check if the new entry is replicated in the follower nodes
+    assert len(raft_node_1._log) == 1 + 3
+    assert raft_node_1._log[0].term == 0
+    assert raft_node_1._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
+    assert raft_node_1._log[0].entry.value == 0
+    assert raft_node_1._log[1].term == 4
+    assert raft_node_1._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
+    assert raft_node_1._log[1].entry.value == 7
+    assert raft_node_1._log[2].term == 5
+    assert raft_node_1._log[2].entry.name.value.tobytes().decode("utf-8") == "top_2"
+    assert raft_node_1._log[2].entry.value == 8
+    assert raft_node_1._log[3].term == 7
+    assert raft_node_1._log[3].entry.name.value.tobytes().decode("utf-8") == "top_3"
+    assert raft_node_1._log[3].entry.value == 10
+    assert raft_node_1._commit_index == 3
+
+    assert len(raft_node_3._log) == 1 + 3
+    assert raft_node_3._log[0].term == 0
+    assert raft_node_3._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
+    assert raft_node_3._log[0].entry.value == 0
+    assert raft_node_3._log[1].term == 4
+    assert raft_node_3._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
+    assert raft_node_3._log[1].entry.value == 7
+    assert raft_node_3._log[2].term == 5
+    assert raft_node_3._log[2].entry.name.value.tobytes().decode("utf-8") == "top_2"
+    assert raft_node_3._log[2].entry.value == 8
+    assert raft_node_3._log[3].term == 7
+    assert raft_node_3._log[3].entry.name.value.tobytes().decode("utf-8") == "top_3"
+    assert raft_node_3._log[3].entry.value == 10
+    assert raft_node_3._commit_index == 3
 
     
     raft_node_1.close()

--- a/tests/raft_log_replication.py
+++ b/tests/raft_log_replication.py
@@ -593,8 +593,310 @@ async def _unittest_raft_log_replication() -> None:
     assert raft_node_1._log[4].entry.name.value.tobytes().decode("utf-8") == "top_4"
     assert raft_node_1._log[4].entry.value == 13
 
+    raft_node_1.close()
+    raft_node_2.close()
+    raft_node_3.close()
+    await asyncio.sleep(1)
+
+# =======================================================================================
+# ========== Test that log replication happens correctly if leadership changes ==========
+# =======================================================================================
+
 
 
 async def _unittest_raft_leader_changes() -> None:
-    # TODO: Test that log replication happens correctly if leadership changes
-    pass
+
+    logging.root.setLevel(logging.INFO)
+
+    os.environ["UAVCAN__SRV__REQUEST_VOTE__ID"] = "1"
+    os.environ["UAVCAN__CLN__REQUEST_VOTE__ID"] = "1"
+    os.environ["UAVCAN__SRV__APPEND_ENTRIES__ID"] = "2"
+    os.environ["UAVCAN__CLN__APPEND_ENTRIES__ID"] = "2"
+
+    TERM_TIMEOUT = 0.5
+    ELECTION_TIMEOUT = 5
+
+    os.environ["UAVCAN__NODE__ID"] = "41"
+    raft_node_1 = RaftNode()
+    raft_node_1.term_timeout = TERM_TIMEOUT
+    raft_node_1.election_timeout = ELECTION_TIMEOUT
+    os.environ["UAVCAN__NODE__ID"] = "42"
+    raft_node_2 = RaftNode()
+    raft_node_2.term_timeout = TERM_TIMEOUT
+    raft_node_2.election_timeout = ELECTION_TIMEOUT + 1
+    os.environ["UAVCAN__NODE__ID"] = "43"
+    raft_node_3 = RaftNode()
+    raft_node_3.term_timeout = TERM_TIMEOUT
+    raft_node_3.election_timeout = ELECTION_TIMEOUT + 1
+
+    # make all part of the same cluster
+    cluster = [raft_node_1._node.id, raft_node_2._node.id, raft_node_3._node.id]
+    raft_node_1.add_remote_node(cluster)
+    raft_node_2.add_remote_node(cluster)
+    raft_node_3.add_remote_node(cluster)
+
+    # start all nodes
+    asyncio.create_task(raft_node_1.run())
+    asyncio.create_task(raft_node_2.run())
+    asyncio.create_task(raft_node_3.run())
+
+    # wait for the leader to be elected
+    await asyncio.sleep(ELECTION_TIMEOUT + 1)
+
+    # check if the leader is elected
+    assert raft_node_1._state == RaftState.LEADER
+    assert raft_node_2._state == RaftState.FOLLOWER
+    assert raft_node_3._state == RaftState.FOLLOWER
+    assert raft_node_1._voted_for == 41
+    assert raft_node_2._voted_for == 41
+    assert raft_node_3._voted_for == 41
+
+    new_entries = [
+        sirius_cyber_corp.LogEntry_1(
+            term=4,
+            entry=sirius_cyber_corp.Entry_1(
+                name=uavcan.primitive.String_1(value="top_1"),
+                value=7,
+            ),
+        ),
+        sirius_cyber_corp.LogEntry_1(
+            term=5,
+            entry=sirius_cyber_corp.Entry_1(
+                name=uavcan.primitive.String_1(value="top_2"),
+                value=8,
+            ),
+        ),
+        sirius_cyber_corp.LogEntry_1(
+            term=6,
+            entry=sirius_cyber_corp.Entry_1(
+                name=uavcan.primitive.String_1(value="top_3"),
+                value=9,
+            ),
+        ),
+    ]
+
+    for index, new_entry in enumerate(new_entries):
+        request = sirius_cyber_corp.AppendEntries_1.Request(
+            term=raft_node_1._term,
+            prev_log_index=index,  # prev_log_index: 0, 1, 2
+            prev_log_term=raft_node_1._log[index].term,
+            log_entry=new_entry,
+        )
+        metadata = pycyphal.presentation.ServiceRequestMetadata(
+            client_node_id=42,
+            timestamp=time.time(),
+            priority=0,
+            transfer_id=0,
+        )
+        response = await raft_node_1._serve_append_entries(request, metadata)
+        assert response.success == True
+    _logger.info("=========Start=========")
+    # wait for the request to be replicated
+    await asyncio.sleep(TERM_TIMEOUT + 1)
+
+    # check if the new entry is replicated in the leader node
+    assert len(raft_node_1._log) == 1 + 3
+    assert raft_node_1._log[0].term == 0
+    assert raft_node_1._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
+    assert raft_node_1._log[0].entry.value == 0
+    assert raft_node_1._log[1].term == 4
+    assert raft_node_1._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
+    assert raft_node_1._log[1].entry.value == 7
+    assert raft_node_1._log[2].term == 5
+    assert raft_node_1._log[2].entry.name.value.tobytes().decode("utf-8") == "top_2"
+    assert raft_node_1._log[2].entry.value == 8
+    assert raft_node_1._log[3].term == 6
+    assert raft_node_1._log[3].entry.name.value.tobytes().decode("utf-8") == "top_3"
+    assert raft_node_1._log[3].entry.value == 9
+    assert raft_node_1._commit_index == 3
+
+    # check if the new entry is replicated in the follower nodes
+    assert len(raft_node_2._log) == 1 + 3
+    assert raft_node_2._log[0].term == 0
+    assert raft_node_2._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
+    assert raft_node_2._log[0].entry.value == 0
+    assert raft_node_2._log[1].term == 4
+    assert raft_node_2._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
+    assert raft_node_2._log[1].entry.value == 7
+    assert raft_node_2._log[2].term == 5
+    assert raft_node_2._log[2].entry.name.value.tobytes().decode("utf-8") == "top_2"
+    assert raft_node_2._log[2].entry.value == 8
+    assert raft_node_2._log[3].term == 6
+    assert raft_node_2._log[3].entry.name.value.tobytes().decode("utf-8") == "top_3"
+    assert raft_node_2._log[3].entry.value == 9
+    assert raft_node_2._commit_index == 3
+
+    assert len(raft_node_3._log) == 1 + 3
+    assert raft_node_3._log[0].term == 0
+    assert raft_node_3._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
+    assert raft_node_3._log[0].entry.value == 0
+    assert raft_node_3._log[1].term == 4
+    assert raft_node_3._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
+    assert raft_node_3._log[1].entry.value == 7
+    assert raft_node_3._log[2].term == 5
+    assert raft_node_3._log[2].entry.name.value.tobytes().decode("utf-8") == "top_2"
+    assert raft_node_3._log[2].entry.value == 8
+    assert raft_node_3._log[3].term == 6
+    assert raft_node_3._log[3].entry.name.value.tobytes().decode("utf-8") == "top_3"
+    assert raft_node_3._log[3].entry.value == 9
+    assert raft_node_3._commit_index == 3
+    
+    await asyncio.sleep(TERM_TIMEOUT + 1)
+    _logger.info("================== TEST 1: change LEADER and check logs ==================")
+
+    # New LEADER => raft_node_2
+
+    raft_node_1.election_timeout = ELECTION_TIMEOUT + 1
+    raft_node_2.election_timeout = ELECTION_TIMEOUT
+    raft_node_3.election_timeout = ELECTION_TIMEOUT + 1
+
+    raft_node_1._change_state(RaftState.FOLLOWER)
+    raft_node_2._change_state(RaftState.FOLLOWER)
+    raft_node_3._change_state(RaftState.FOLLOWER)
+    raft_node_1._voted_for = None
+
+
+    await asyncio.sleep(ELECTION_TIMEOUT + 1)
+
+    assert raft_node_1._state == RaftState.FOLLOWER
+    assert raft_node_1._term == 1, "received heartbeat from LEADER"
+    assert raft_node_1._voted_for == 42
+
+    assert raft_node_2._state == RaftState.LEADER
+    assert raft_node_2._term == 1
+    assert raft_node_2._voted_for == 42
+
+    assert raft_node_3._state == RaftState.FOLLOWER
+    assert raft_node_3._term == 1, "received heartbeat from LEADER"
+    assert raft_node_3._voted_for == 42
+
+    # check that all logs are saved from previous LEADER
+    assert len(raft_node_1._log) == 1 + 3
+    assert raft_node_1._log[0].term == 0
+    assert raft_node_1._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
+    assert raft_node_1._log[0].entry.value == 0
+    assert raft_node_1._log[1].term == 4
+    assert raft_node_1._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
+    assert raft_node_1._log[1].entry.value == 7
+    assert raft_node_1._log[2].term == 5
+    assert raft_node_1._log[2].entry.name.value.tobytes().decode("utf-8") == "top_2"
+    assert raft_node_1._log[2].entry.value == 8
+    assert raft_node_1._log[3].term == 6
+    assert raft_node_1._log[3].entry.name.value.tobytes().decode("utf-8") == "top_3"
+    assert raft_node_1._log[3].entry.value == 9
+    assert raft_node_1._commit_index == 3
+
+    assert len(raft_node_2._log) == 1 + 3
+    assert raft_node_2._log[0].term == 0
+    assert raft_node_2._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
+    assert raft_node_2._log[0].entry.value == 0
+    assert raft_node_2._log[1].term == 4
+    assert raft_node_2._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
+    assert raft_node_2._log[1].entry.value == 7
+    assert raft_node_2._log[2].term == 5
+    assert raft_node_2._log[2].entry.name.value.tobytes().decode("utf-8") == "top_2"
+    assert raft_node_2._log[2].entry.value == 8
+    assert raft_node_2._log[3].term == 6
+    assert raft_node_2._log[3].entry.name.value.tobytes().decode("utf-8") == "top_3"
+    assert raft_node_2._log[3].entry.value == 9
+    assert raft_node_2._commit_index == 3
+
+    assert len(raft_node_3._log) == 1 + 3
+    assert raft_node_3._log[0].term == 0
+    assert raft_node_3._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
+    assert raft_node_3._log[0].entry.value == 0
+    assert raft_node_3._log[1].term == 4
+    assert raft_node_3._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
+    assert raft_node_3._log[1].entry.value == 7
+    assert raft_node_3._log[2].term == 5
+    assert raft_node_3._log[2].entry.name.value.tobytes().decode("utf-8") == "top_2"
+    assert raft_node_3._log[2].entry.value == 8
+    assert raft_node_3._log[3].term == 6
+    assert raft_node_3._log[3].entry.name.value.tobytes().decode("utf-8") == "top_3"
+    assert raft_node_3._log[3].entry.value == 9
+    assert raft_node_3._commit_index == 3
+
+    _logger.info("================== TEST 2: append new log entry fron another LEADER ==================")
+
+    new_entry = sirius_cyber_corp.LogEntry_1(
+        term=7,
+        entry=sirius_cyber_corp.Entry_1(
+            name=uavcan.primitive.String_1(value="top_4"),
+            value=13,
+        ),
+    )
+    request = sirius_cyber_corp.AppendEntries_1.Request(
+        term=raft_node_2._term,
+        prev_log_index=3,  # index of top_3
+        prev_log_term=raft_node_2._log[3].term,
+        log_entry=new_entry,
+    )
+    metadata = pycyphal.presentation.ServiceRequestMetadata(
+        client_node_id=43,
+        timestamp=time.time(),
+        priority=0,
+        transfer_id=0,
+    )
+
+    response = await raft_node_2._serve_append_entries(request, metadata)
+    _logger.info("=========END=========")
+    assert response.success == True
+
+    await asyncio.sleep(TERM_TIMEOUT + 1)
+
+    assert len(raft_node_2._log) == 1 + 4
+    assert raft_node_2._log[0].term == 0
+    assert raft_node_2._log[0].entry.value == 0
+    assert raft_node_2._log[1].term == 4
+    assert raft_node_2._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
+    assert raft_node_2._log[1].entry.value == 7
+    assert raft_node_2._log[2].term == 5
+    assert raft_node_2._log[2].entry.name.value.tobytes().decode("utf-8") == "top_2"
+    assert raft_node_2._log[2].entry.value == 8
+    assert raft_node_2._log[3].term == 6
+    assert raft_node_2._log[3].entry.name.value.tobytes().decode("utf-8") == "top_3"
+    assert raft_node_2._log[3].entry.value == 9
+    assert raft_node_2._log[4].term == 7
+    assert raft_node_2._log[4].entry.name.value.tobytes().decode("utf-8") == "top_4"
+    assert raft_node_2._log[4].entry.value == 13
+    assert raft_node_2._commit_index == 4
+
+    assert len(raft_node_1._log) == 1 + 4
+    assert raft_node_1._log[0].term == 0
+    assert raft_node_1._log[0].entry.value == 0
+    assert raft_node_1._log[1].term == 4
+    assert raft_node_1._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
+    assert raft_node_1._log[1].entry.value == 7
+    assert raft_node_1._log[2].term == 5
+    assert raft_node_1._log[2].entry.name.value.tobytes().decode("utf-8") == "top_2"
+    assert raft_node_1._log[2].entry.value == 8
+    assert raft_node_1._log[3].term == 6
+    assert raft_node_1._log[3].entry.name.value.tobytes().decode("utf-8") == "top_3"
+    assert raft_node_1._log[3].entry.value == 9
+    assert raft_node_1._log[4].term == 7
+    assert raft_node_1._log[4].entry.name.value.tobytes().decode("utf-8") == "top_4"
+    assert raft_node_1._log[4].entry.value == 13
+    assert raft_node_1._commit_index == 4
+    
+    assert len(raft_node_3._log) == 1 + 4
+    assert raft_node_3._log[0].term == 0
+    assert raft_node_3._log[0].entry.value == 0
+    assert raft_node_3._log[1].term == 4
+    assert raft_node_3._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
+    assert raft_node_3._log[1].entry.value == 7
+    assert raft_node_3._log[2].term == 5
+    assert raft_node_3._log[2].entry.name.value.tobytes().decode("utf-8") == "top_2"
+    assert raft_node_3._log[2].entry.value == 8
+    assert raft_node_3._log[3].term == 6
+    assert raft_node_3._log[3].entry.name.value.tobytes().decode("utf-8") == "top_3"
+    assert raft_node_3._log[3].entry.value == 9
+    assert raft_node_3._log[4].term == 7
+    assert raft_node_3._log[4].entry.name.value.tobytes().decode("utf-8") == "top_4"
+    assert raft_node_3._log[4].entry.value == 13
+    assert raft_node_3._commit_index == 4
+
+    
+    raft_node_1.close()
+    raft_node_2.close()
+    raft_node_3.close()
+    await asyncio.sleep(1)

--- a/tests/raft_log_replication.py
+++ b/tests/raft_log_replication.py
@@ -963,7 +963,9 @@ async def _unittest_raft_leader_changes() -> None:
     raft_node_4.close()
     await asyncio.sleep(1)
 
-    _logger.info("================== TEST 3: Replace Log Entry 3 with a New Entry from LEADER Node 42 ==================")
+    _logger.info(
+        "================== TEST 3: Replace Log Entry 3 with a New Entry from LEADER Node 42 =================="
+    )
 
     await asyncio.sleep(TERM_TIMEOUT)
 

--- a/tests/raft_node.py
+++ b/tests/raft_node.py
@@ -242,6 +242,124 @@ async def _unittest_raft_node_request_vote_rpc() -> None:
     await asyncio.sleep(1)
 
 
+async def _unittest_raft_node_heartbeat() -> None:
+    """
+    Test that the node does NOT convert to candidate if it receives a heartbeat message
+    """
+    os.environ["UAVCAN__NODE__ID"] = "41"
+    raft_node = RaftNode()
+    ELECTION_TIMEOUT = 5
+    TERM_TIMEOUT = 1
+    raft_node.election_timeout = ELECTION_TIMEOUT
+    raft_node.term_timeout = TERM_TIMEOUT
+    raft_node._voted_for = 42
+
+    asyncio.create_task(raft_node.run())
+    await asyncio.sleep(ELECTION_TIMEOUT * 0.90)  # sleep until right before election timeout
+
+    # send heartbeat
+    terms_passed = raft_node._term  # leader's term is equal to the follower's term
+    await raft_node._serve_append_entries(
+        sirius_cyber_corp.AppendEntries_1.Request(
+            term=terms_passed,  # leader's term
+            prev_log_index=0,  # index of log entry immediately preceding new ones
+            prev_log_term=0,  # term of prevLogIndex entry
+            leader_commit=0,  # leader's commitIndex
+            log_entry=None,  # log entries to store (empty for heartbeat)
+        ),
+        pycyphal.presentation.ServiceRequestMetadata(
+            client_node_id=42,  # leader's node id
+            timestamp=time.time(),  # leader's timestamp
+            priority=0,  # leader's priority
+            transfer_id=0,  # leader's transfer id
+        ),
+    )
+
+    # wait for heartbeat to be processed [election is reached but shouldn't become leader due to heartbeat]
+    await asyncio.sleep(ELECTION_TIMEOUT * 0.1 + 0.1)
+    assert raft_node._state == RaftState.FOLLOWER
+    assert raft_node._voted_for == 42
+
+    # send heartbeat again
+    # (this time leader has a higher term, we want to make sure that the follower's term is updated)
+    await asyncio.sleep(ELECTION_TIMEOUT * 0.90)  # sleep until right before election timeout
+    terms_passed = raft_node._term + 5  # leader's term is higher than the follower's term
+    await raft_node._serve_append_entries(
+        sirius_cyber_corp.AppendEntries_1.Request(
+            term=terms_passed,  # leader's term
+            prev_log_index=0,  # index of log entry immediately preceding new ones
+            prev_log_term=0,  # term of prevLogIndex entry
+            leader_commit=0,  # leader's commitIndex
+            log_entry=None,  # log entries to store (empty for heartbeat)
+        ),
+        pycyphal.presentation.ServiceRequestMetadata(
+            client_node_id=42,  # leader's node id
+            timestamp=time.time(),  # leader's timestamp
+            priority=0,  # leader's priority
+            transfer_id=0,  # leader's transfer id
+        ),
+    )
+
+    # wait for heartbeat to be processed [election is reached but shouldn't become leader due to heartbeat]
+    await asyncio.sleep(ELECTION_TIMEOUT * 0.1 + 0.1)
+    assert raft_node._state == RaftState.FOLLOWER
+    assert raft_node._voted_for == 42
+    assert raft_node._term == terms_passed
+
+    # send heartbeat again
+    # (this time from a different leader with a higher term, we want to make sure the follower switches leader and updates term)
+    await asyncio.sleep(ELECTION_TIMEOUT * 0.90)  # sleep until right before election timeout
+    terms_passed = raft_node._term + 5  # leader's term is higher than the follower's term
+    await raft_node._serve_append_entries(
+        sirius_cyber_corp.AppendEntries_1.Request(
+            term=terms_passed,  # leader's term
+            prev_log_index=0,  # index of log entry immediately preceding new ones
+            prev_log_term=0,  # term of prevLogIndex entry
+            leader_commit=0,  # leader's commitIndex
+            log_entry=None,  # log entries to store (empty for heartbeat)
+        ),
+        pycyphal.presentation.ServiceRequestMetadata(
+            client_node_id=43,  # leader's node id (different from previous leader)
+            timestamp=time.time(),  # leader's timestamp
+            priority=0,  # leader's priority
+            transfer_id=0,  # leader's transfer id
+        ),
+    )
+
+    # wait for heartbeat to be processed [election is reached but shouldn't become leader due to heartbeat]
+    await asyncio.sleep(ELECTION_TIMEOUT * 0.1 + 0.1)
+    assert raft_node._state == RaftState.FOLLOWER
+    assert raft_node._voted_for == 43
+    assert raft_node._term == terms_passed
+
+    # send heartbeat again
+    # (this time the leader's term is lower than the follower's term, we want to make sure the follower doesn't switch leader)
+    await asyncio.sleep(ELECTION_TIMEOUT * 0.90)  # sleep until right before election timeout
+    terms_passed = raft_node._term - 1  # leader's term is lower than the follower's term
+    await raft_node._serve_append_entries(
+        sirius_cyber_corp.AppendEntries_1.Request(
+            term=terms_passed,  # leader's term
+            prev_log_index=0,  # index of log entry immediately preceding new ones
+            prev_log_term=0,  # term of prevLogIndex entry
+            leader_commit=0,  # leader's commitIndex
+            log_entry=None,  # log entries to store (empty for heartbeat)
+        ),
+        pycyphal.presentation.ServiceRequestMetadata(
+            client_node_id=42,  # old leader's node id, which has lower term
+            timestamp=time.time(),  # leader's timestamp
+            priority=0,  # leader's priority
+            transfer_id=0,  # leader's transfer id
+        ),
+    )
+
+    ## test that the node converts to candidate after the election timeout [no valid heartbeat is received]
+    await asyncio.sleep(ELECTION_TIMEOUT * 0.1 + 0.1)
+    assert raft_node._prev_state == RaftState.CANDIDATE
+
+    raft_node.close()
+    await asyncio.sleep(1)  # fixes when just running this test, however not when "pytest /cyraft" is run
+
+
 async def _unittest_raft_node_start_election() -> None:
     """
     Test the _start_election method

--- a/tests/raft_node.py
+++ b/tests/raft_node.py
@@ -124,9 +124,7 @@ async def _unittest_raft_node_term_timeout() -> None:
     raft_node._change_state(RaftState.LEADER)  # only leader can increase term
 
     await asyncio.sleep(TERM_TIMEOUT)  # + 0.1 to make sure the timer has been reset
-    assert (
-        raft_node._term == 0
-    )  # 0 because we have manually set the node to leader (instead of waiting for election)
+    assert raft_node._term == 0  # 0 because we have manually set the node to leader (instead of waiting for election)
     await asyncio.sleep(TERM_TIMEOUT)
     assert raft_node._term == 0
     assert raft_node._term == 0
@@ -200,9 +198,7 @@ async def _unittest_raft_node_request_vote_rpc() -> None:
     raft_node._voted_for = None  # node has not voted for any candidate
     raft_node._term = request.term + 1
 
-    assert (
-        request.term < raft_node._term
-    )  # follower node term is greater than candidate's term
+    assert request.term < raft_node._term  # follower node term is greater than candidate's term
     response = await raft_node._serve_request_vote(request, metadata)
     assert raft_node._voted_for == None
     assert response.vote_granted == False
@@ -212,30 +208,22 @@ async def _unittest_raft_node_request_vote_rpc() -> None:
     raft_node._voted_for = None
     raft_node._term = request.term - 1
 
-    assert (
-        request.term > raft_node._term
-    )  # follower node term is less than candidate's term
+    assert request.term > raft_node._term  # follower node term is less than candidate's term
     response = await raft_node._serve_request_vote(request, metadata)
     assert raft_node._voted_for == 42
     assert response.vote_granted == True
-    assert (
-        raft_node._term == request.term
-    )  # follower node term is updated to candidate's term
+    assert raft_node._term == request.term  # follower node term is updated to candidate's term
 
     # test 4: vote granted if not voted for another candidate
     #         and the candidate's term is EQUAL to the node's term
     raft_node._voted_for = None
     raft_node._term = request.term - 1
 
-    assert (
-        request.term > raft_node._term
-    )  # follower node term is less than candidate's term
+    assert request.term > raft_node._term  # follower node term is less than candidate's term
     response = await raft_node._serve_request_vote(request, metadata)
     assert raft_node._voted_for == 42
     assert response.vote_granted == True
-    assert (
-        raft_node._term == request.term
-    )  # follower node term is updated to candidate's term
+    assert raft_node._term == request.term  # follower node term is updated to candidate's term
     raft_node.close()
     await asyncio.sleep(1)
     raft_node.close()
@@ -255,9 +243,7 @@ async def _unittest_raft_node_heartbeat() -> None:
     raft_node._voted_for = 42
 
     asyncio.create_task(raft_node.run())
-    await asyncio.sleep(
-        ELECTION_TIMEOUT * 0.90
-    )  # sleep until right before election timeout
+    await asyncio.sleep(ELECTION_TIMEOUT * 0.90)  # sleep until right before election timeout
 
     # send heartbeat
     terms_passed = raft_node._term  # leader's term is equal to the follower's term
@@ -284,12 +270,8 @@ async def _unittest_raft_node_heartbeat() -> None:
 
     # send heartbeat again
     # (this time leader has a higher term, we want to make sure that the follower's term is updated)
-    await asyncio.sleep(
-        ELECTION_TIMEOUT * 0.90
-    )  # sleep until right before election timeout
-    terms_passed = (
-        raft_node._term + 5
-    )  # leader's term is higher than the follower's term
+    await asyncio.sleep(ELECTION_TIMEOUT * 0.90)  # sleep until right before election timeout
+    terms_passed = raft_node._term + 5  # leader's term is higher than the follower's term
     await raft_node._serve_append_entries(
         sirius_cyber_corp.AppendEntries_1.Request(
             term=terms_passed,  # leader's term
@@ -314,12 +296,8 @@ async def _unittest_raft_node_heartbeat() -> None:
 
     # send heartbeat again
     # (this time from a different leader with a higher term, we want to make sure the follower switches leader and updates term)
-    await asyncio.sleep(
-        ELECTION_TIMEOUT * 0.90
-    )  # sleep until right before election timeout
-    terms_passed = (
-        raft_node._term + 5
-    )  # leader's term is higher than the follower's term
+    await asyncio.sleep(ELECTION_TIMEOUT * 0.90)  # sleep until right before election timeout
+    terms_passed = raft_node._term + 5  # leader's term is higher than the follower's term
     await raft_node._serve_append_entries(
         sirius_cyber_corp.AppendEntries_1.Request(
             term=terms_passed,  # leader's term
@@ -344,12 +322,8 @@ async def _unittest_raft_node_heartbeat() -> None:
 
     # send heartbeat again
     # (this time the leader's term is lower than the follower's term, we want to make sure the follower doesn't switch leader)
-    await asyncio.sleep(
-        ELECTION_TIMEOUT * 0.90
-    )  # sleep until right before election timeout
-    terms_passed = (
-        raft_node._term - 1
-    )  # leader's term is lower than the follower's term
+    await asyncio.sleep(ELECTION_TIMEOUT * 0.90)  # sleep until right before election timeout
+    terms_passed = raft_node._term - 1  # leader's term is lower than the follower's term
     await raft_node._serve_append_entries(
         sirius_cyber_corp.AppendEntries_1.Request(
             term=terms_passed,  # leader's term
@@ -371,9 +345,7 @@ async def _unittest_raft_node_heartbeat() -> None:
     assert raft_node._prev_state == RaftState.CANDIDATE
 
     raft_node.close()
-    await asyncio.sleep(
-        1
-    )  # fixes when just running this test, however not when "pytest /cyraft" is run
+    await asyncio.sleep(1)  # fixes when just running this test, however not when "pytest /cyraft" is run
 
 
 async def _unittest_raft_node_start_election() -> None:
@@ -542,9 +514,7 @@ async def _unittest_raft_node_append_entries_rpc() -> None:
 
     assert len(raft_node._log) == 1 + 3
     assert raft_node._log[0].term == 0
-    assert (
-        raft_node._log[0].entry.name.value.tobytes().decode("utf-8") == ""
-    )  # index zero entry is empty
+    assert raft_node._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
     assert raft_node._log[0].entry.value == 0
     assert raft_node._log[1].term == 4
     assert raft_node._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
@@ -563,9 +533,7 @@ async def _unittest_raft_node_append_entries_rpc() -> None:
     # assert raft_node.log[2] == new_entries[1]
     # assert raft_node.log[3] == new_entries[2]
 
-    _logger.info(
-        "================== TEST 2: Replace log entry 3 with a new entry =================="
-    )
+    _logger.info("================== TEST 2: Replace log entry 3 with a new entry ==================")
 
     new_entry = sirius_cyber_corp.LogEntry_1(
         term=7,
@@ -594,9 +562,7 @@ async def _unittest_raft_node_append_entries_rpc() -> None:
 
     assert len(raft_node._log) == 1 + 3
     assert raft_node._log[0].term == 0
-    assert (
-        raft_node._log[0].entry.name.value.tobytes().decode("utf-8") == ""
-    )  # index zero entry is empty
+    assert raft_node._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
     assert raft_node._log[0].entry.value == 0
 
     assert raft_node._log[1].term == 4
@@ -610,9 +576,7 @@ async def _unittest_raft_node_append_entries_rpc() -> None:
     assert raft_node._log[3].entry.value == 10
     assert raft_node._commit_index == 3
 
-    _logger.info(
-        "================== TEST 3: Replace log entries 2 and 3 with new entries =================="
-    )
+    _logger.info("================== TEST 3: Replace log entries 2 and 3 with new entries ==================")
 
     new_entries = [
         sirius_cyber_corp.LogEntry_1(
@@ -663,9 +627,7 @@ async def _unittest_raft_node_append_entries_rpc() -> None:
     assert raft_node._log[3].entry.name.value.tobytes().decode("utf-8") == "top_3"
     assert raft_node._log[3].entry.value == 12
 
-    _logger.info(
-        "================== TEST 4: Add an already existing log entry =================="
-    )
+    _logger.info("================== TEST 4: Add an already existing log entry ==================")
 
     new_entry = sirius_cyber_corp.LogEntry_1(
         term=9,
@@ -706,9 +668,7 @@ async def _unittest_raft_node_append_entries_rpc() -> None:
     assert raft_node._log[3].entry.name.value.tobytes().decode("utf-8") == "top_3"
     assert raft_node._log[3].entry.value == 12
 
-    _logger.info(
-        "================== TEST 5: Add an additional log entry =================="
-    )
+    _logger.info("================== TEST 5: Add an additional log entry ==================")
 
     new_entry = sirius_cyber_corp.LogEntry_1(
         term=10,
@@ -751,9 +711,7 @@ async def _unittest_raft_node_append_entries_rpc() -> None:
     assert raft_node._log[4].entry.name.value.tobytes().decode("utf-8") == "top_4"
     assert raft_node._log[4].entry.value == 13
 
-    _logger.info(
-        "================== TEST 6: Try to append old log entry (term < currentTerm) =================="
-    )
+    _logger.info("================== TEST 6: Try to append old log entry (term < currentTerm) ==================")
 
     new_entry = sirius_cyber_corp.LogEntry_1(
         term=9,

--- a/tests/raft_node.py
+++ b/tests/raft_node.py
@@ -97,6 +97,8 @@ async def _unittest_raft_node_init() -> None:
     assert raft_node._next_index == [1]
     raft_node.close()
     await asyncio.sleep(1)
+    raft_node.close()
+    await asyncio.sleep(1)
     # assert raft_node._match_index == [0]
     raft_node.close()
     await asyncio.sleep(1)
@@ -227,6 +229,7 @@ async def _unittest_raft_node_request_vote_rpc() -> None:
     await asyncio.sleep(1)
     raft_node.close()
     await asyncio.sleep(1)
+
 
 async def _unittest_raft_node_start_election() -> None:
     """
@@ -676,4 +679,5 @@ async def _unittest_raft_node_append_entries_rpc() -> None:
     assert raft_node._log[3].entry.value == 12
     assert raft_node._log[4].term == 10
     assert raft_node._log[4].entry.value == 13
-    
+    raft_node.close()
+    await asyncio.sleep(1)

--- a/tests/raft_node.py
+++ b/tests/raft_node.py
@@ -120,7 +120,7 @@ async def _unittest_raft_node_term_timeout() -> None:
     raft_node._change_state(RaftState.LEADER)  # only leader can increase term
 
     await asyncio.sleep(TERM_TIMEOUT)  # + 0.1 to make sure the timer has been reset
-    assert raft_node._term == 0
+    assert raft_node._term == 0 # 0 because we have manually set the node to leader (instead of waiting for election)
     await asyncio.sleep(TERM_TIMEOUT)
     assert raft_node._term == 0
     assert raft_node._term == 0

--- a/tests/raft_node.py
+++ b/tests/raft_node.py
@@ -98,11 +98,13 @@ async def _unittest_raft_node_init() -> None:
     # assert raft_node._match_index == [0]
     raft_node.close()
     await asyncio.sleep(1)
+    raft_node.close()
+    await asyncio.sleep(1)
 
 
 async def _unittest_raft_node_term_timeout() -> None:
     """
-    Test that the LEADER node term is not increased by term timeout (this is only done by election timeout)
+
     Test that the CANDIDATE/FOLLOWER node term is not increased upon term timeout
     """
 
@@ -118,14 +120,17 @@ async def _unittest_raft_node_term_timeout() -> None:
     raft_node._change_state(RaftState.LEADER)  # only leader can increase term
 
     await asyncio.sleep(TERM_TIMEOUT)  # + 0.1 to make sure the timer has been reset
-    assert raft_node._term == 0 # 0 because we have manually set the node to leader (instead of waiting for election)
-    await asyncio.sleep(TERM_TIMEOUT)
     assert raft_node._term == 0
     await asyncio.sleep(TERM_TIMEOUT)
+    assert raft_node._term == 0
+    assert raft_node._term == 0
+    await asyncio.sleep(TERM_TIMEOUT)
+    assert raft_node._term == 0
     assert raft_node._term == 0
 
     raft_node._change_state(RaftState.FOLLOWER)  # follower should not increase term
     await asyncio.sleep(TERM_TIMEOUT)
+    assert raft_node._term == 0
     assert raft_node._term == 0
 
     raft_node.close()
@@ -335,6 +340,8 @@ async def _unittest_raft_node_request_vote_rpc() -> None:
     assert raft_node._term == request.term  # follower node term is updated to candidate's term
     raft_node.close()
     await asyncio.sleep(1)
+    raft_node.close()
+    await asyncio.sleep(1)
 
 async def _unittest_raft_node_start_election() -> None:
     """
@@ -388,59 +395,59 @@ async def _unittest_raft_node_append_entries_rpc() -> None:
     """
     Test the _serve_append_entries method
 
-     Step 1: Append 3 log entries
+    Step 1: Append 3 log entries
        ____________ ____________ ____________ ____________
       | 0          | 1          | 2          | 3          |     Log index
-      | 0          | 4          | 5          | 6          |     Log term
+      | 0          | 0          | 0          | 0          |     Log term
       | empty <= 0 | top_1 <= 7 | top_2 <= 8 | top_3 <= 9 |     Name <= value
       |____________|____________|____________|____________|
 
      Step 2: Replace log entry 3 with a new entry
        ____________
       | 3          |     Log index
-      | 7          |     Log term
+      | 1          |     Log term
       | top_3 <= 10|     Name <= value
       |____________|
 
      Step 3: Replace log entries 2 and 3 with new entries
        ____________ ____________
       | 2          | 3          |     Log index
-      | 8          | 9          |     Log term
+      | 2          | 2          |     Log term
       | top_2 <= 11| top_3 <= 12|     Name <= value
       |____________|____________|
 
      Step 4: Add an already existing log entry
        ____________
       | 3          |     Log index
-      | 9          |     Log term
+      | 3          |     Log term
       | top_3 <= 12|     Name <= value
       |____________|
 
      Step 5: Add an additional log entry
        ____________
       | 4          |     Log index
-      | 10         |     Log term
+      | 3          |     Log term
       | top_4 <= 13|     Name <= value
       |____________|
 
      Result:
        ____________ ____________ ____________ ____________ ____________
       | 0          | 1          | 2          | 3          | 4          |     Log index
-      | 0          | 4          | 8          | 9          | 10         |     Log term
+      | 0          | 0          | 1          | 3          | 3          |     Log term
       | empty <= 0 | top_1 <= 7 | top_2 <= 10| top_3 <= 11| top_4 <= 13|     Name <= value
-      |____________|____________|____________|____________|____________|
+      |____________|____________|___________|____________|_____________|
 
      Step 6: Try to append old log entry (term < currentTerm)
        ____________
       | 4          |     Log index
-      | 9          |     Log term
+      | 2          |     Log term
       | top_4 <= 14|     Name <= value
       |____________|
 
      Step 7: Try to append valid log entry, however entry at prev_log_index term does not match
        ____________
       | 4          |     Log index
-      | 11         |     Log term
+      | 4          |     Log term
       | top_4 <= 15|     Name <= value
       |____________|
 
@@ -459,21 +466,21 @@ async def _unittest_raft_node_append_entries_rpc() -> None:
     _logger.info("================== TEST 1: append 3 log entries ==================")
     new_entries = [
         sirius_cyber_corp.LogEntry_1(
-            term=4,
+            term=0,
             entry=sirius_cyber_corp.Entry_1(
                 name=uavcan.primitive.String_1(value="top_1"),
                 value=7,
             ),
         ),
         sirius_cyber_corp.LogEntry_1(
-            term=5,
+            term=0,
             entry=sirius_cyber_corp.Entry_1(
                 name=uavcan.primitive.String_1(value="top_2"),
                 value=8,
             ),
         ),
         sirius_cyber_corp.LogEntry_1(
-            term=6,
+            term=0,
             entry=sirius_cyber_corp.Entry_1(
                 name=uavcan.primitive.String_1(value="top_3"),
                 value=9,
@@ -483,7 +490,7 @@ async def _unittest_raft_node_append_entries_rpc() -> None:
 
     for index, new_entry in enumerate(new_entries):
         request = sirius_cyber_corp.AppendEntries_1.Request(
-            term=6,
+            term=0,
             prev_log_index=index,  # prev_log_index: 0, 1, 2
             prev_log_term=raft_node._log[index].term,
             log_entry=new_entry,
@@ -497,20 +504,20 @@ async def _unittest_raft_node_append_entries_rpc() -> None:
         response = await raft_node._serve_append_entries(request, metadata)
         assert response.success == True
 
-    assert raft_node._term == 6
+    assert raft_node._term == 0
     assert raft_node._voted_for == 42
 
     assert len(raft_node._log) == 1 + 3
     assert raft_node._log[0].term == 0
     assert raft_node._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
     assert raft_node._log[0].entry.value == 0
-    assert raft_node._log[1].term == 4
+    assert raft_node._log[1].term == 0
     assert raft_node._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
     assert raft_node._log[1].entry.value == 7
-    assert raft_node._log[2].term == 5
+    assert raft_node._log[2].term == 0
     assert raft_node._log[2].entry.name.value.tobytes().decode("utf-8") == "top_2"
     assert raft_node._log[2].entry.value == 8
-    assert raft_node._log[3].term == 6
+    assert raft_node._log[3].term == 0
     assert raft_node._log[3].entry.name.value.tobytes().decode("utf-8") == "top_3"
     assert raft_node._log[3].entry.value == 9
     assert raft_node._commit_index == 3
@@ -524,14 +531,14 @@ async def _unittest_raft_node_append_entries_rpc() -> None:
     _logger.info("================== TEST 2: Replace log entry 3 with a new entry ==================")
 
     new_entry = sirius_cyber_corp.LogEntry_1(
-        term=7,
+        term=1,
         entry=sirius_cyber_corp.Entry_1(
             name=uavcan.primitive.String_1(value="top_3"),
             value=10,
         ),
     )
     request = sirius_cyber_corp.AppendEntries_1.Request(
-        term=7,
+        term=1,
         prev_log_index=2,  # index of top_2
         prev_log_term=raft_node._log[2].term,
         log_entry=new_entry,
@@ -545,7 +552,7 @@ async def _unittest_raft_node_append_entries_rpc() -> None:
     response = await raft_node._serve_append_entries(request, metadata)
     assert response.success == True
 
-    assert raft_node._term == 7
+    assert raft_node._term == 1
     assert raft_node._voted_for == 42
 
     assert len(raft_node._log) == 1 + 3
@@ -553,13 +560,13 @@ async def _unittest_raft_node_append_entries_rpc() -> None:
     assert raft_node._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
     assert raft_node._log[0].entry.value == 0
 
-    assert raft_node._log[1].term == 4
+    assert raft_node._log[1].term == 0
     assert raft_node._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
     assert raft_node._log[1].entry.value == 7
-    assert raft_node._log[2].term == 5
+    assert raft_node._log[2].term == 0
     assert raft_node._log[2].entry.name.value.tobytes().decode("utf-8") == "top_2"
     assert raft_node._log[2].entry.value == 8
-    assert raft_node._log[3].term == 7
+    assert raft_node._log[3].term == 1
     assert raft_node._log[3].entry.name.value.tobytes().decode("utf-8") == "top_3"
     assert raft_node._log[3].entry.value == 10
     assert raft_node._commit_index == 3
@@ -568,14 +575,14 @@ async def _unittest_raft_node_append_entries_rpc() -> None:
 
     new_entries = [
         sirius_cyber_corp.LogEntry_1(
-            term=8,
+            term=2,
             entry=sirius_cyber_corp.Entry_1(
                 name=uavcan.primitive.String_1(value="top_2"),
                 value=11,
             ),
         ),
         sirius_cyber_corp.LogEntry_1(
-            term=9,
+            term=2,
             entry=sirius_cyber_corp.Entry_1(
                 name=uavcan.primitive.String_1(value="top_3"),
                 value=12,
@@ -585,7 +592,7 @@ async def _unittest_raft_node_append_entries_rpc() -> None:
 
     for index, new_entry in enumerate(new_entries):
         request = sirius_cyber_corp.AppendEntries_1.Request(
-            term=9,
+            term=2,
             prev_log_index=index + 1,  # index: 1, 2
             prev_log_term=raft_node._log[index + 1].term,
             log_entry=new_entry,
@@ -599,33 +606,33 @@ async def _unittest_raft_node_append_entries_rpc() -> None:
         response = await raft_node._serve_append_entries(request, metadata)
         assert response.success == True
 
-    assert raft_node._term == 9
+    assert raft_node._term == 2
     assert raft_node._voted_for == 42
 
     assert len(raft_node._log) == 1 + 3
     assert raft_node._log[0].term == 0
     assert raft_node._log[0].entry.value == 0
-    assert raft_node._log[1].term == 4
+    assert raft_node._log[1].term == 0
     assert raft_node._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
     assert raft_node._log[1].entry.value == 7
-    assert raft_node._log[2].term == 8
+    assert raft_node._log[2].term == 2
     assert raft_node._log[2].entry.name.value.tobytes().decode("utf-8") == "top_2"
     assert raft_node._log[2].entry.value == 11
-    assert raft_node._log[3].term == 9
+    assert raft_node._log[3].term == 2
     assert raft_node._log[3].entry.name.value.tobytes().decode("utf-8") == "top_3"
     assert raft_node._log[3].entry.value == 12
 
     _logger.info("================== TEST 4: Add an already existing log entry ==================")
 
     new_entry = sirius_cyber_corp.LogEntry_1(
-        term=9,
+        term=3,
         entry=sirius_cyber_corp.Entry_1(
             name=uavcan.primitive.String_1(value="top_3"),
             value=12,
         ),
     )
     request = sirius_cyber_corp.AppendEntries_1.Request(
-        term=9,
+        term=3,
         prev_log_index=2,  # index of top_2
         prev_log_term=raft_node._log[2].term,
         log_entry=new_entry,
@@ -640,33 +647,33 @@ async def _unittest_raft_node_append_entries_rpc() -> None:
     response = await raft_node._serve_append_entries(request, metadata)
     assert response.success == True
 
-    assert raft_node._term == 9
+    assert raft_node._term == 3
     assert raft_node._voted_for == 42
 
     assert len(raft_node._log) == 1 + 3
     assert raft_node._log[0].term == 0
     assert raft_node._log[0].entry.value == 0
-    assert raft_node._log[1].term == 4
+    assert raft_node._log[1].term == 0
     assert raft_node._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
     assert raft_node._log[1].entry.value == 7
-    assert raft_node._log[2].term == 8
+    assert raft_node._log[2].term == 2
     assert raft_node._log[2].entry.name.value.tobytes().decode("utf-8") == "top_2"
     assert raft_node._log[2].entry.value == 11
-    assert raft_node._log[3].term == 9
+    assert raft_node._log[3].term == 3
     assert raft_node._log[3].entry.name.value.tobytes().decode("utf-8") == "top_3"
     assert raft_node._log[3].entry.value == 12
 
     _logger.info("================== TEST 5: Add an additional log entry ==================")
 
     new_entry = sirius_cyber_corp.LogEntry_1(
-        term=10,
+        term=3,
         entry=sirius_cyber_corp.Entry_1(
             name=uavcan.primitive.String_1(value="top_4"),
             value=13,
         ),
     )
     request = sirius_cyber_corp.AppendEntries_1.Request(
-        term=10,
+        term=3,
         prev_log_index=3,  # index of top_3
         prev_log_term=raft_node._log[3].term,
         log_entry=new_entry,
@@ -680,36 +687,36 @@ async def _unittest_raft_node_append_entries_rpc() -> None:
     response = await raft_node._serve_append_entries(request, metadata)
     assert response.success == True
 
-    assert raft_node._term == 10
+    assert raft_node._term == 3
     assert raft_node._voted_for == 42
 
     assert len(raft_node._log) == 1 + 4
     assert raft_node._log[0].term == 0
     assert raft_node._log[0].entry.value == 0
-    assert raft_node._log[1].term == 4
+    assert raft_node._log[1].term == 0
     assert raft_node._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
     assert raft_node._log[1].entry.value == 7
-    assert raft_node._log[2].term == 8
+    assert raft_node._log[2].term == 2
     assert raft_node._log[2].entry.name.value.tobytes().decode("utf-8") == "top_2"
     assert raft_node._log[2].entry.value == 11
-    assert raft_node._log[3].term == 9
+    assert raft_node._log[3].term == 3
     assert raft_node._log[3].entry.name.value.tobytes().decode("utf-8") == "top_3"
     assert raft_node._log[3].entry.value == 12
-    assert raft_node._log[4].term == 10
+    assert raft_node._log[4].term == 3
     assert raft_node._log[4].entry.name.value.tobytes().decode("utf-8") == "top_4"
     assert raft_node._log[4].entry.value == 13
 
     _logger.info("================== TEST 6: Try to append old log entry (term < currentTerm) ==================")
 
     new_entry = sirius_cyber_corp.LogEntry_1(
-        term=9,
+        term=2,
         entry=sirius_cyber_corp.Entry_1(
             name=uavcan.primitive.String_1(value="top_4"),
             value=14,
         ),
     )
     request = sirius_cyber_corp.AppendEntries_1.Request(
-        term=9,
+        term=2,
         prev_log_index=3,
         prev_log_term=raft_node._log[3].term,
         log_entry=new_entry,
@@ -723,22 +730,22 @@ async def _unittest_raft_node_append_entries_rpc() -> None:
     response = await raft_node._serve_append_entries(request, metadata)
     assert response.success == False
 
-    assert raft_node._term == 10
+    assert raft_node._term == 3
     assert raft_node._voted_for == 42
 
     assert len(raft_node._log) == 1 + 4
     assert raft_node._log[0].term == 0
     assert raft_node._log[0].entry.value == 0
-    assert raft_node._log[1].term == 4
+    assert raft_node._log[1].term == 0
     assert raft_node._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
     assert raft_node._log[1].entry.value == 7
-    assert raft_node._log[2].term == 8
+    assert raft_node._log[2].term == 2
     assert raft_node._log[2].entry.name.value.tobytes().decode("utf-8") == "top_2"
     assert raft_node._log[2].entry.value == 11
-    assert raft_node._log[3].term == 9
+    assert raft_node._log[3].term == 3
     assert raft_node._log[3].entry.name.value.tobytes().decode("utf-8") == "top_3"
     assert raft_node._log[3].entry.value == 12
-    assert raft_node._log[4].term == 10
+    assert raft_node._log[4].term == 3
     assert raft_node._log[4].entry.name.value.tobytes().decode("utf-8") == "top_4"
     assert raft_node._log[4].entry.value == 13
 
@@ -747,14 +754,14 @@ async def _unittest_raft_node_append_entries_rpc() -> None:
     )
 
     new_entry = sirius_cyber_corp.LogEntry_1(
-        term=11,
+        term=4,
         entry=sirius_cyber_corp.Entry_1(
             name=uavcan.primitive.String_1(value="top_4"),
             value=15,
         ),
     )
     request = sirius_cyber_corp.AppendEntries_1.Request(
-        term=11,
+        term=4,
         prev_log_index=4,
         prev_log_term=raft_node._log[4].term - 1,  # term mismatch
         log_entry=new_entry,
@@ -768,18 +775,18 @@ async def _unittest_raft_node_append_entries_rpc() -> None:
     response = await raft_node._serve_append_entries(request, metadata)
     assert response.success == False
 
-    assert raft_node._term == 10
+    assert raft_node._term == 3
     assert raft_node._voted_for == 42
 
     assert len(raft_node._log) == 1 + 4
     assert raft_node._log[0].term == 0
     assert raft_node._log[0].entry.value == 0
-    assert raft_node._log[1].term == 4
+    assert raft_node._log[1].term == 0
     assert raft_node._log[1].entry.value == 7
-    assert raft_node._log[2].term == 8
+    assert raft_node._log[2].term == 2
     assert raft_node._log[2].entry.value == 11
-    assert raft_node._log[3].term == 9
+    assert raft_node._log[3].term == 3
     assert raft_node._log[3].entry.value == 12
-    assert raft_node._log[4].term == 10
+    assert raft_node._log[4].term == 3
     assert raft_node._log[4].entry.value == 13
     

--- a/tests/raft_node.py
+++ b/tests/raft_node.py
@@ -392,6 +392,8 @@ async def _unittest_raft_node_append_entries_rpc() -> None:
     assert raft_node._term == 6
     assert raft_node._voted_for == 42
 
+
+
     assert len(raft_node._log) == 1 + 3
     assert raft_node._log[0].term == 0
     assert raft_node._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty

--- a/tests/raft_node.py
+++ b/tests/raft_node.py
@@ -95,6 +95,8 @@ async def _unittest_raft_node_init() -> None:
     assert len(raft_node._request_vote_clients) == 1
     assert len(raft_node._append_entries_clients) == 1
     assert raft_node._next_index == [1]
+    raft_node.close()
+    await asyncio.sleep(1)
     # assert raft_node._match_index == [0]
     raft_node.close()
     await asyncio.sleep(1)
@@ -160,123 +162,6 @@ async def _unittest_raft_node_election_timeout() -> None:
     raft_node.close()
     await asyncio.sleep(1)  # give some time for the node to close
 
-
-async def _unittest_raft_node_heartbeat() -> None:
-    """
-    Test that the node does NOT convert to candidate if it receives a heartbeat message
-    """
-    os.environ["UAVCAN__NODE__ID"] = "41"
-    raft_node = RaftNode()
-    ELECTION_TIMEOUT = 5
-    TERM_TIMEOUT = 1
-    raft_node.election_timeout = ELECTION_TIMEOUT
-    raft_node.term_timeout = TERM_TIMEOUT
-    raft_node._voted_for = 42
-
-    asyncio.create_task(raft_node.run())
-    await asyncio.sleep(ELECTION_TIMEOUT * 0.90)  # sleep until right before election timeout
-
-    # send heartbeat
-    terms_passed = raft_node._term  # leader's term is equal to the follower's term
-    await raft_node._serve_append_entries(
-        sirius_cyber_corp.AppendEntries_1.Request(
-            term=terms_passed,  # leader's term
-            prev_log_index=0,  # index of log entry immediately preceding new ones
-            prev_log_term=0,  # term of prevLogIndex entry
-            leader_commit=0,  # leader's commitIndex
-            log_entry=None,  # log entries to store (empty for heartbeat)
-        ),
-        pycyphal.presentation.ServiceRequestMetadata(
-            client_node_id=42,  # leader's node id
-            timestamp=time.time(),  # leader's timestamp
-            priority=0,  # leader's priority
-            transfer_id=0,  # leader's transfer id
-        ),
-    )
-
-    # wait for heartbeat to be processed [election is reached but shouldn't become leader due to heartbeat]
-    await asyncio.sleep(ELECTION_TIMEOUT * 0.1 + 0.1)
-    assert raft_node._state == RaftState.FOLLOWER
-    assert raft_node._voted_for == 42
-
-    # send heartbeat again
-    # (this time leader has a higher term, we want to make sure that the follower's term is updated)
-    await asyncio.sleep(ELECTION_TIMEOUT * 0.90)  # sleep until right before election timeout
-    terms_passed = raft_node._term + 5  # leader's term is higher than the follower's term
-    await raft_node._serve_append_entries(
-        sirius_cyber_corp.AppendEntries_1.Request(
-            term=terms_passed,  # leader's term
-            prev_log_index=0,  # index of log entry immediately preceding new ones
-            prev_log_term=0,  # term of prevLogIndex entry
-            leader_commit=0,  # leader's commitIndex
-            log_entry=None,  # log entries to store (empty for heartbeat)
-        ),
-        pycyphal.presentation.ServiceRequestMetadata(
-            client_node_id=42,  # leader's node id
-            timestamp=time.time(),  # leader's timestamp
-            priority=0,  # leader's priority
-            transfer_id=0,  # leader's transfer id
-        ),
-    )
-
-    # wait for heartbeat to be processed [election is reached but shouldn't become leader due to heartbeat]
-    await asyncio.sleep(ELECTION_TIMEOUT * 0.1 + 0.1)
-    assert raft_node._state == RaftState.FOLLOWER
-    assert raft_node._voted_for == 42
-    assert raft_node._term == terms_passed
-
-    # send heartbeat again
-    # (this time from a different leader with a higher term, we want to make sure the follower switches leader and updates term)
-    await asyncio.sleep(ELECTION_TIMEOUT * 0.90)  # sleep until right before election timeout
-    terms_passed = raft_node._term + 5  # leader's term is higher than the follower's term
-    await raft_node._serve_append_entries(
-        sirius_cyber_corp.AppendEntries_1.Request(
-            term=terms_passed,  # leader's term
-            prev_log_index=0,  # index of log entry immediately preceding new ones
-            prev_log_term=0,  # term of prevLogIndex entry
-            leader_commit=0,  # leader's commitIndex
-            log_entry=None,  # log entries to store (empty for heartbeat)
-        ),
-        pycyphal.presentation.ServiceRequestMetadata(
-            client_node_id=43,  # leader's node id (different from previous leader)
-            timestamp=time.time(),  # leader's timestamp
-            priority=0,  # leader's priority
-            transfer_id=0,  # leader's transfer id
-        ),
-    )
-
-    # wait for heartbeat to be processed [election is reached but shouldn't become leader due to heartbeat]
-    await asyncio.sleep(ELECTION_TIMEOUT * 0.1 + 0.1)
-    assert raft_node._state == RaftState.FOLLOWER
-    assert raft_node._voted_for == 43
-    assert raft_node._term == terms_passed
-
-    # send heartbeat again
-    # (this time the leader's term is lower than the follower's term, we want to make sure the follower doesn't switch leader)
-    await asyncio.sleep(ELECTION_TIMEOUT * 0.90)  # sleep until right before election timeout
-    terms_passed = raft_node._term - 1  # leader's term is lower than the follower's term
-    await raft_node._serve_append_entries(
-        sirius_cyber_corp.AppendEntries_1.Request(
-            term=terms_passed,  # leader's term
-            prev_log_index=0,  # index of log entry immediately preceding new ones
-            prev_log_term=0,  # term of prevLogIndex entry
-            leader_commit=0,  # leader's commitIndex
-            log_entry=None,  # log entries to store (empty for heartbeat)
-        ),
-        pycyphal.presentation.ServiceRequestMetadata(
-            client_node_id=42,  # old leader's node id, which has lower term
-            timestamp=time.time(),  # leader's timestamp
-            priority=0,  # leader's priority
-            transfer_id=0,  # leader's transfer id
-        ),
-    )
-
-    ## test that the node converts to candidate after the election timeout [no valid heartbeat is received]
-    await asyncio.sleep(ELECTION_TIMEOUT * 0.1 + 0.1)
-    assert raft_node._prev_state == RaftState.CANDIDATE
-
-    raft_node.close()
-    await asyncio.sleep(1)  # fixes when just running this test, however not when "pytest /cyraft" is run
 
 
 async def _unittest_raft_node_request_vote_rpc() -> None:

--- a/tests/raft_node.py
+++ b/tests/raft_node.py
@@ -255,7 +255,9 @@ async def _unittest_raft_node_heartbeat() -> None:
     raft_node._voted_for = 42
 
     asyncio.create_task(raft_node.run())
-    await asyncio.sleep(ELECTION_TIMEOUT * 0.90)  # sleep until right before election timeout
+    await asyncio.sleep(
+        ELECTION_TIMEOUT * 0.90
+    )  # sleep until right before election timeout
 
     # send heartbeat
     terms_passed = raft_node._term  # leader's term is equal to the follower's term
@@ -282,8 +284,12 @@ async def _unittest_raft_node_heartbeat() -> None:
 
     # send heartbeat again
     # (this time leader has a higher term, we want to make sure that the follower's term is updated)
-    await asyncio.sleep(ELECTION_TIMEOUT * 0.90)  # sleep until right before election timeout
-    terms_passed = raft_node._term + 5  # leader's term is higher than the follower's term
+    await asyncio.sleep(
+        ELECTION_TIMEOUT * 0.90
+    )  # sleep until right before election timeout
+    terms_passed = (
+        raft_node._term + 5
+    )  # leader's term is higher than the follower's term
     await raft_node._serve_append_entries(
         sirius_cyber_corp.AppendEntries_1.Request(
             term=terms_passed,  # leader's term
@@ -308,8 +314,12 @@ async def _unittest_raft_node_heartbeat() -> None:
 
     # send heartbeat again
     # (this time from a different leader with a higher term, we want to make sure the follower switches leader and updates term)
-    await asyncio.sleep(ELECTION_TIMEOUT * 0.90)  # sleep until right before election timeout
-    terms_passed = raft_node._term + 5  # leader's term is higher than the follower's term
+    await asyncio.sleep(
+        ELECTION_TIMEOUT * 0.90
+    )  # sleep until right before election timeout
+    terms_passed = (
+        raft_node._term + 5
+    )  # leader's term is higher than the follower's term
     await raft_node._serve_append_entries(
         sirius_cyber_corp.AppendEntries_1.Request(
             term=terms_passed,  # leader's term
@@ -334,8 +344,12 @@ async def _unittest_raft_node_heartbeat() -> None:
 
     # send heartbeat again
     # (this time the leader's term is lower than the follower's term, we want to make sure the follower doesn't switch leader)
-    await asyncio.sleep(ELECTION_TIMEOUT * 0.90)  # sleep until right before election timeout
-    terms_passed = raft_node._term - 1  # leader's term is lower than the follower's term
+    await asyncio.sleep(
+        ELECTION_TIMEOUT * 0.90
+    )  # sleep until right before election timeout
+    terms_passed = (
+        raft_node._term - 1
+    )  # leader's term is lower than the follower's term
     await raft_node._serve_append_entries(
         sirius_cyber_corp.AppendEntries_1.Request(
             term=terms_passed,  # leader's term
@@ -357,7 +371,9 @@ async def _unittest_raft_node_heartbeat() -> None:
     assert raft_node._prev_state == RaftState.CANDIDATE
 
     raft_node.close()
-    await asyncio.sleep(1)  # fixes when just running this test, however not when "pytest /cyraft" is run
+    await asyncio.sleep(
+        1
+    )  # fixes when just running this test, however not when "pytest /cyraft" is run
 
 
 async def _unittest_raft_node_start_election() -> None:

--- a/tests/raft_node.py
+++ b/tests/raft_node.py
@@ -12,7 +12,7 @@ import uavcan
 
 # Add parent directory to Python path
 # Get the absolute path of the parent directory
-parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 # Add the parent directory to the Python path
 sys.path.append(parent_dir)
 # This can be removed if setting PYTHONPATH (export PYTHONPATH=cyraft)
@@ -124,7 +124,9 @@ async def _unittest_raft_node_term_timeout() -> None:
     raft_node._change_state(RaftState.LEADER)  # only leader can increase term
 
     await asyncio.sleep(TERM_TIMEOUT)  # + 0.1 to make sure the timer has been reset
-    assert raft_node._term == 0 # 0 because we have manually set the node to leader (instead of waiting for election)
+    assert (
+        raft_node._term == 0
+    )  # 0 because we have manually set the node to leader (instead of waiting for election)
     await asyncio.sleep(TERM_TIMEOUT)
     assert raft_node._term == 0
     assert raft_node._term == 0
@@ -165,7 +167,6 @@ async def _unittest_raft_node_election_timeout() -> None:
     await asyncio.sleep(1)  # give some time for the node to close
 
 
-
 async def _unittest_raft_node_request_vote_rpc() -> None:
     """
     Test the _serve_request_vote() method
@@ -199,7 +200,9 @@ async def _unittest_raft_node_request_vote_rpc() -> None:
     raft_node._voted_for = None  # node has not voted for any candidate
     raft_node._term = request.term + 1
 
-    assert request.term < raft_node._term  # follower node term is greater than candidate's term
+    assert (
+        request.term < raft_node._term
+    )  # follower node term is greater than candidate's term
     response = await raft_node._serve_request_vote(request, metadata)
     assert raft_node._voted_for == None
     assert response.vote_granted == False
@@ -209,22 +212,30 @@ async def _unittest_raft_node_request_vote_rpc() -> None:
     raft_node._voted_for = None
     raft_node._term = request.term - 1
 
-    assert request.term > raft_node._term  # follower node term is less than candidate's term
+    assert (
+        request.term > raft_node._term
+    )  # follower node term is less than candidate's term
     response = await raft_node._serve_request_vote(request, metadata)
     assert raft_node._voted_for == 42
     assert response.vote_granted == True
-    assert raft_node._term == request.term  # follower node term is updated to candidate's term
+    assert (
+        raft_node._term == request.term
+    )  # follower node term is updated to candidate's term
 
     # test 4: vote granted if not voted for another candidate
     #         and the candidate's term is EQUAL to the node's term
     raft_node._voted_for = None
     raft_node._term = request.term - 1
 
-    assert request.term > raft_node._term  # follower node term is less than candidate's term
+    assert (
+        request.term > raft_node._term
+    )  # follower node term is less than candidate's term
     response = await raft_node._serve_request_vote(request, metadata)
     assert raft_node._voted_for == 42
     assert response.vote_granted == True
-    assert raft_node._term == request.term  # follower node term is updated to candidate's term
+    assert (
+        raft_node._term == request.term
+    )  # follower node term is updated to candidate's term
     raft_node.close()
     await asyncio.sleep(1)
     raft_node.close()
@@ -395,11 +406,11 @@ async def _unittest_raft_node_append_entries_rpc() -> None:
     assert raft_node._term == 6
     assert raft_node._voted_for == 42
 
-
-
     assert len(raft_node._log) == 1 + 3
     assert raft_node._log[0].term == 0
-    assert raft_node._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
+    assert (
+        raft_node._log[0].entry.name.value.tobytes().decode("utf-8") == ""
+    )  # index zero entry is empty
     assert raft_node._log[0].entry.value == 0
     assert raft_node._log[1].term == 4
     assert raft_node._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
@@ -418,7 +429,9 @@ async def _unittest_raft_node_append_entries_rpc() -> None:
     # assert raft_node.log[2] == new_entries[1]
     # assert raft_node.log[3] == new_entries[2]
 
-    _logger.info("================== TEST 2: Replace log entry 3 with a new entry ==================")
+    _logger.info(
+        "================== TEST 2: Replace log entry 3 with a new entry =================="
+    )
 
     new_entry = sirius_cyber_corp.LogEntry_1(
         term=7,
@@ -447,7 +460,9 @@ async def _unittest_raft_node_append_entries_rpc() -> None:
 
     assert len(raft_node._log) == 1 + 3
     assert raft_node._log[0].term == 0
-    assert raft_node._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
+    assert (
+        raft_node._log[0].entry.name.value.tobytes().decode("utf-8") == ""
+    )  # index zero entry is empty
     assert raft_node._log[0].entry.value == 0
 
     assert raft_node._log[1].term == 4
@@ -461,7 +476,9 @@ async def _unittest_raft_node_append_entries_rpc() -> None:
     assert raft_node._log[3].entry.value == 10
     assert raft_node._commit_index == 3
 
-    _logger.info("================== TEST 3: Replace log entries 2 and 3 with new entries ==================")
+    _logger.info(
+        "================== TEST 3: Replace log entries 2 and 3 with new entries =================="
+    )
 
     new_entries = [
         sirius_cyber_corp.LogEntry_1(
@@ -512,7 +529,9 @@ async def _unittest_raft_node_append_entries_rpc() -> None:
     assert raft_node._log[3].entry.name.value.tobytes().decode("utf-8") == "top_3"
     assert raft_node._log[3].entry.value == 12
 
-    _logger.info("================== TEST 4: Add an already existing log entry ==================")
+    _logger.info(
+        "================== TEST 4: Add an already existing log entry =================="
+    )
 
     new_entry = sirius_cyber_corp.LogEntry_1(
         term=9,
@@ -553,7 +572,9 @@ async def _unittest_raft_node_append_entries_rpc() -> None:
     assert raft_node._log[3].entry.name.value.tobytes().decode("utf-8") == "top_3"
     assert raft_node._log[3].entry.value == 12
 
-    _logger.info("================== TEST 5: Add an additional log entry ==================")
+    _logger.info(
+        "================== TEST 5: Add an additional log entry =================="
+    )
 
     new_entry = sirius_cyber_corp.LogEntry_1(
         term=10,
@@ -596,7 +617,9 @@ async def _unittest_raft_node_append_entries_rpc() -> None:
     assert raft_node._log[4].entry.name.value.tobytes().decode("utf-8") == "top_4"
     assert raft_node._log[4].entry.value == 13
 
-    _logger.info("================== TEST 6: Try to append old log entry (term < currentTerm) ==================")
+    _logger.info(
+        "================== TEST 6: Try to append old log entry (term < currentTerm) =================="
+    )
 
     new_entry = sirius_cyber_corp.LogEntry_1(
         term=9,


### PR DESCRIPTION
In node.py: expanded the log information for some values ​​to make it easier to analyze the code

In raft_log_replication.py: start to write test that log replication happens correctly if leadership changes

In raft_node.py: add a couple of lines of code to close node after each test, so that after running pytest it does not crash

new issue: after the leader changes, the new leader is not aware of the latest index of the neighboring nodes and begins to rewrite them, even though his nodes completely coincide with the neighboring node.