### PR TITLE
Update term timeout

### DIFF
--- a/cyraft/node.py
+++ b/cyraft/node.py
@@ -833,9 +833,9 @@ class RaftNode:
                     self._node.id,
                     self._cluster[self._current_follower],
                 )
-                task = asyncio.create_task(self._send_heartbeat(self._next_index[self._current_follower]))
+                task = asyncio.create_task(self._send_heartbeat(self._current_follower))
             else:  # remote log is not up to date, send append entries request
-                task = asyncio.create_task(self._send_append_entry(self._next_index[self._current_follower]))
+                task = asyncio.create_task(self._send_append_entry(self._current_follower))
 
             self._term_timeout_tasks[self._current_follower] = task
             self._current_follower += 1

--- a/tests/raft_leader_election.py
+++ b/tests/raft_leader_election.py
@@ -414,3 +414,92 @@ async def _unittest_raft_fsm_4():
     raft_node_2.close()
     raft_node_3.close()
     await asyncio.sleep(1)
+
+
+# Test for checking the leader can continue sending values ​​to followers even if some follower disappears from the cluster and reappears
+async def _unittest_follower_not_response() -> None:
+    logging.root.setLevel(logging.INFO)
+
+    os.environ["UAVCAN__SRV__REQUEST_VOTE__ID"] = "1"
+    os.environ["UAVCAN__CLN__REQUEST_VOTE__ID"] = "1"
+    os.environ["UAVCAN__SRV__APPEND_ENTRIES__ID"] = "2"
+    os.environ["UAVCAN__CLN__APPEND_ENTRIES__ID"] = "2"
+
+    TERM_TIMEOUT = 0.1
+    ELECTION_TIMEOUT = 2
+
+    os.environ["UAVCAN__NODE__ID"] = "41"
+    raft_node_1 = RaftNode()
+    raft_node_1.term_timeout = TERM_TIMEOUT
+    raft_node_1.election_timeout = ELECTION_TIMEOUT
+    os.environ["UAVCAN__NODE__ID"] = "42"
+    raft_node_2 = RaftNode()
+    raft_node_2.term_timeout = TERM_TIMEOUT
+    raft_node_2.election_timeout = ELECTION_TIMEOUT
+    os.environ["UAVCAN__NODE__ID"] = "43"
+    raft_node_3 = RaftNode()
+    raft_node_3.term_timeout = TERM_TIMEOUT
+    raft_node_3.election_timeout = ELECTION_TIMEOUT - 1  # raft_node_3 should be a leader
+
+    # make all part of the same cluster
+    cluster = [raft_node_1._node.id, raft_node_2._node.id, raft_node_3._node.id]
+    raft_node_1.add_remote_node(cluster)
+    raft_node_2.add_remote_node(cluster)
+    raft_node_3.add_remote_node(cluster)
+
+    asyncio.create_task(raft_node_1.run())
+    asyncio.create_task(raft_node_2.run())
+    asyncio.create_task(raft_node_3.run())
+
+    # Wait for the election timeout to allow the nodes to elect a leader
+    await asyncio.sleep(ELECTION_TIMEOUT + 1)
+
+    assert raft_node_3._state == RaftState.LEADER
+    assert raft_node_1._state == RaftState.FOLLOWER
+    assert raft_node_2._state == RaftState.FOLLOWER
+
+    # Check that raft_node_1 and raft_node_2 have voted for raft_node_3
+    assert raft_node_1._voted_for == 43
+    assert raft_node_2._voted_for == 43
+    await asyncio.sleep(TERM_TIMEOUT * 3)
+
+    _logger.info(
+        "================== TEST STAGE 1: Test that after closing raft_node_2, the cluster works without freezing =================="
+    )
+
+    # Close raft_node_2 to simulate a node failure
+    raft_node_2.close()
+
+    await asyncio.sleep(ELECTION_TIMEOUT + 1)
+
+    # Check that raft_node_3 is still the leader and raft_node_1 is still a follower
+    assert raft_node_3._state == RaftState.LEADER
+    assert raft_node_1._state == RaftState.FOLLOWER
+    assert raft_node_2._state == RaftState.FOLLOWER
+    assert raft_node_1._voted_for == 43
+
+    _logger.info(
+        "================== TEST STAGE 2: After the raft_node_2 returns, the cluster continues its work again with two followers. =================="
+    )
+
+    # Recreate raft_node_2 with the same ID and configuration
+    os.environ["UAVCAN__NODE__ID"] = "42"
+    raft_node_2 = RaftNode()
+    raft_node_2.term_timeout = TERM_TIMEOUT
+    raft_node_2.election_timeout = ELECTION_TIMEOUT
+    asyncio.create_task(raft_node_2.run())
+
+    await asyncio.sleep(ELECTION_TIMEOUT + 1)
+
+    # Check that raft_node_3 is still the leader and both raft_node_1 and raft_node_2 are followers
+    assert raft_node_3._state == RaftState.LEADER
+    assert raft_node_1._state == RaftState.FOLLOWER
+    assert raft_node_2._state == RaftState.FOLLOWER
+
+    assert raft_node_1._voted_for == 43
+    assert raft_node_2._voted_for == 43
+
+    raft_node_1.close()
+    raft_node_2.close()
+    raft_node_3.close()
+    await asyncio.sleep(1)

--- a/tests/raft_leader_election.py
+++ b/tests/raft_leader_election.py
@@ -348,7 +348,7 @@ async def _unittest_raft_fsm_4():
     os.environ["UAVCAN__SRV__APPEND_ENTRIES__ID"] = "2"
     os.environ["UAVCAN__CLN__APPEND_ENTRIES__ID"] = "2"
 
-    TERM_TIMEOUT = 0.5
+    TERM_TIMEOUT = 1
     ELECTION_TIMEOUT = 5
 
     _logger.info("================== TEST STAGE 9/10: 2 CANDIDATEs, higher term get's elected ==================")

--- a/tests/raft_log_replication.py
+++ b/tests/raft_log_replication.py
@@ -93,7 +93,7 @@ async def _unittest_raft_log_replication() -> None:
     os.environ["UAVCAN__SRV__APPEND_ENTRIES__ID"] = "2"
     os.environ["UAVCAN__CLN__APPEND_ENTRIES__ID"] = "2"
 
-    TERM_TIMEOUT = 0.5
+    TERM_TIMEOUT = 0.1
     ELECTION_TIMEOUT = 5
 
     os.environ["UAVCAN__NODE__ID"] = "41"
@@ -593,11 +593,6 @@ async def _unittest_raft_log_replication() -> None:
     assert raft_node_1._log[4].entry.name.value.tobytes().decode("utf-8") == "top_4"
     assert raft_node_1._log[4].entry.value == 13
 
-    raft_node_1.close()
-    raft_node_2.close()
-    raft_node_3.close()
-    await asyncio.sleep(1)
-
 
 """
 =======================================================================================
@@ -652,7 +647,7 @@ async def _unittest_raft_leader_changes() -> None:
     os.environ["UAVCAN__SRV__APPEND_ENTRIES__ID"] = "2"
     os.environ["UAVCAN__CLN__APPEND_ENTRIES__ID"] = "2"
 
-    TERM_TIMEOUT = 0.5
+    TERM_TIMEOUT = 0.1
     ELECTION_TIMEOUT = 5
 
     os.environ["UAVCAN__NODE__ID"] = "41"
@@ -666,11 +661,11 @@ async def _unittest_raft_leader_changes() -> None:
     os.environ["UAVCAN__NODE__ID"] = "43"
     raft_node_3 = RaftNode()
     raft_node_3.term_timeout = TERM_TIMEOUT
-    raft_node_3.election_timeout = ELECTION_TIMEOUT + 2
+    raft_node_3.election_timeout = ELECTION_TIMEOUT + 4
     os.environ["UAVCAN__NODE__ID"] = "44"
     raft_node_4 = RaftNode()
     raft_node_4.term_timeout = TERM_TIMEOUT
-    raft_node_4.election_timeout = ELECTION_TIMEOUT + 2.1
+    raft_node_4.election_timeout = ELECTION_TIMEOUT + 4
 
     # make all part of the same cluster
     cluster = [
@@ -820,7 +815,7 @@ async def _unittest_raft_leader_changes() -> None:
     raft_node_1.close()  # Simulation of the disappearance of a leader from a cluster
 
     await asyncio.sleep(
-        ELECTION_TIMEOUT + 9 * TERM_TIMEOUT
+        ELECTION_TIMEOUT + 9
     )  # Nine terms are needed for complete replication of logs from the leader to the followers.
 
     assert raft_node_2._state == RaftState.LEADER
@@ -1037,7 +1032,6 @@ async def _unittest_raft_leader_changes() -> None:
     assert raft_node_3._log[3].entry.name.value.tobytes().decode("utf-8") == "top_3"
     assert raft_node_3._log[3].entry.value == 9
     assert raft_node_3._commit_index == 4
-
     raft_node_2.close()
     raft_node_3.close()
     raft_node_4.close()


### PR DESCRIPTION
I rewrote the [_on_term_timeout(self)](https://github.com/Parsifal22/cyraft/blob/9504d06092f9e35cdc896265e8415ac916dd9aec/cyraft/node.py#L717) method in much the same way as Pavel did in the [libcyphal project](https://github.com/OpenCyphal-Garage/libcyphal/blob/dcc3a4de237b7482e04543d2393c3a9385685312/libuavcan/include/uavcan/protocol/dynamic_node_id_server/distributed/raft_core.hpp#L260-L316). 
In a nutshell. In the rewritten version, the method is called more often and sends a heartbeat to only one follower. If the follower fails to complete the task within the allotted time (if it is not in the cluster or simply stalls), then with the next call to _on_election_timeout(self) it cancels the heartbeat request and sends a heartbeat to another follower.