### PR TITLE
Update append entry methode

### DIFF
--- a/cyraft/node.py
+++ b/cyraft/node.py
@@ -395,7 +395,10 @@ class RaftNode:
             )
             return sirius_cyber_corp.AppendEntries_1.Response(term=self._term, success=False)
         # Update the log with new entries - this will possibly require to rewrite existing entries.
-        if request.prev_log_index + 1 != len(self._log):
+        if (
+            request.prev_log_index + 1 != len(self._log) - 1
+            or request.log_entry[0].term != self._log[request.prev_log_index + 1].term
+        ):
             _logger.info(
                 c["append_entries"] + "Node ID: %d -- deleting from: %d" + c["end_color"],
                 self._node.id,

--- a/cyraft/node.py
+++ b/cyraft/node.py
@@ -626,9 +626,8 @@ class RaftNode:
                     if self._state != RaftState.LEADER:
                         return
                     self._next_index[remote_node_index] -= 1
-                    await self._send_append_entry(remote_node_index)
-                else:
-                    pass
+
+                await self._send_append_entry(remote_node_index)
         else:
             _logger.info(
                 c["raft_logic"] + "Node ID: %d -- Remote node %d log update failed (unreachable)" + c["end_color"],

--- a/cyraft/node.py
+++ b/cyraft/node.py
@@ -394,11 +394,11 @@ class RaftNode:
             )
             return sirius_cyber_corp.AppendEntries_1.Response(term=self._term, success=False)
         # Update the log with new entries - this will possibly require to rewrite existing entries.
-        if request.prev_log_index != len(self._log):
+        if request.prev_log_index + 1 != len(self._log):
             _logger.info(
                 c["append_entries"] + "Node ID: %d -- deleting from: %d" + c["end_color"],
                 self._node.id,
-                request.prev_log_index,
+                request.prev_log_index + 1,
             )
             number_of_entries_to_delete = len(self._log) - (request.prev_log_index + 1)
             self._next_index = [x - number_of_entries_to_delete for x in self._next_index]

--- a/cyraft/node.py
+++ b/cyraft/node.py
@@ -703,12 +703,23 @@ class RaftNode:
             c["raft_logic"] + "Node ID: %d -- Resetting election timeout" + c["end_color"],
             self._node.id,
         )
+
         loop = asyncio.get_event_loop()
         if hasattr(self, "_election_timer"):
             self._election_timer.cancel()
         self._election_timer = loop.call_later(
             self._election_timeout,
             lambda: asyncio.create_task(self._on_election_timeout()),
+        )
+
+        # Calculate and print the delay
+        scheduled_time = self._election_timer.when()
+        current_time = time.time()
+        delay = scheduled_time - current_time
+        _logger.info(
+            c["raft_logic"] + "Node ID: %d -- Delay until election timeout: %.2f seconds" + c["end_color"],
+            self._node.id,
+            delay,
         )
 
     def _reset_term_timeout(self) -> None:

--- a/tests/raft_log_replication.py
+++ b/tests/raft_log_replication.py
@@ -640,6 +640,8 @@ async def _unittest_raft_log_replication() -> None:
   | empty <= 0 | top_1 <= 7 | top_2 <= 8 | top_3 <= 10 |     Name <= value
   |____________|____________|____________|_____________|
   
+    Step 4: Restore node 41 with epty log and fill it again
+
 """
 
 
@@ -1031,6 +1033,38 @@ async def _unittest_raft_leader_changes() -> None:
     assert raft_node_3._log[3].entry.value == 10
     assert raft_node_3._commit_index == 3
 
+    _logger.info("================== TEST 4: Restore node 41 with epty log ==================")
+
+    os.environ["UAVCAN__NODE__ID"] = "41"
+    raft_node_1 = RaftNode()
+    raft_node_1.term_timeout = TERM_TIMEOUT
+    raft_node_1.election_timeout = ELECTION_TIMEOUT
+
+    # check if the new entry is replicated in the leader node
+    assert len(raft_node_1._log) == 1
+    assert raft_node_1._log[0].term == 0
+    assert raft_node_1._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
+    assert raft_node_1._log[0].entry.value == 0
+    assert raft_node_1._commit_index == 0
+
+    await asyncio.sleep(ELECTION_TIMEOUT + 1)
+
+    assert len(raft_node_1._log) == 1 + 3
+    assert raft_node_1._log[0].term == 0
+    assert raft_node_1._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
+    assert raft_node_1._log[0].entry.value == 0
+    assert raft_node_1._log[1].term == 1
+    assert raft_node_1._log[1].entry.name.value.tobytes().decode("utf-8") == "top_1"
+    assert raft_node_1._log[1].entry.value == 7
+    assert raft_node_1._log[2].term == 1
+    assert raft_node_1._log[2].entry.name.value.tobytes().decode("utf-8") == "top_2"
+    assert raft_node_1._log[2].entry.value == 8
+    assert raft_node_1._log[3].term == 2
+    assert raft_node_1._log[3].entry.name.value.tobytes().decode("utf-8") == "top_3"
+    assert raft_node_1._log[3].entry.value == 10
+    assert raft_node_1._commit_index == 3
+
+    raft_node_1.close()
     raft_node_2.close()
     raft_node_3.close()
     raft_node_4.close()

--- a/tests/raft_log_replication.py
+++ b/tests/raft_log_replication.py
@@ -834,7 +834,7 @@ async def _unittest_raft_leader_changes() -> None:
     assert raft_node_3._state == RaftState.FOLLOWER
     assert raft_node_3._term == 2, "received heartbeat from LEADER"
     assert raft_node_3._voted_for == 42
-
+    await asyncio.sleep(ELECTION_TIMEOUT + 2)
     # check that all logs are saved from previous LEADER
     assert len(raft_node_2._log) == 1 + 3
     assert raft_node_2._log[0].term == 0

--- a/tests/raft_log_replication.py
+++ b/tests/raft_log_replication.py
@@ -809,7 +809,7 @@ async def _unittest_raft_leader_changes() -> None:
     assert raft_node_4._log[3].entry.value == 9
     assert raft_node_4._commit_index == 3
 
-    await asyncio.sleep(TERM_TIMEOUT + 1)
+    await asyncio.sleep(TERM_TIMEOUT)
 
     _logger.info("================== TEST 2: Leadership Change to Node 42 and Add New Entry  ==================")
 
@@ -819,9 +819,7 @@ async def _unittest_raft_leader_changes() -> None:
 
     raft_node_1.close()  # Simulation of the disappearance of a leader from a cluster
 
-    await asyncio.sleep(
-        ELECTION_TIMEOUT + 9 * TERM_TIMEOUT
-    )  # Nine terms are needed for complete replication of logs from the leader to the followers.
+    await asyncio.sleep(ELECTION_TIMEOUT + 2)
 
     assert raft_node_2._state == RaftState.LEADER
     assert raft_node_2._term == 2
@@ -958,11 +956,6 @@ async def _unittest_raft_leader_changes() -> None:
     assert raft_node_4._log[4].entry.value == 13
     assert raft_node_4._commit_index == 4
 
-    raft_node_2.close()
-    raft_node_3.close()
-    raft_node_4.close()
-    await asyncio.sleep(1)
-
     _logger.info(
         "================== TEST 3: Replace Log Entry 3 with a New Entry from LEADER Node 42 =================="
     )
@@ -1009,7 +1002,7 @@ async def _unittest_raft_leader_changes() -> None:
     assert raft_node_2._commit_index == 3
 
     # check if the new entry is replicated in the follower nodes
-    assert len(raft_node_4._log) == 1 + 4
+    assert len(raft_node_4._log) == 1 + 3
     assert raft_node_4._log[0].term == 0
     assert raft_node_4._log[0].entry.value == 0
     assert raft_node_4._log[1].term == 1
@@ -1018,12 +1011,12 @@ async def _unittest_raft_leader_changes() -> None:
     assert raft_node_4._log[2].term == 1
     assert raft_node_4._log[2].entry.name.value.tobytes().decode("utf-8") == "top_2"
     assert raft_node_4._log[2].entry.value == 8
-    assert raft_node_4._log[3].term == 1
+    assert raft_node_4._log[3].term == 2
     assert raft_node_4._log[3].entry.name.value.tobytes().decode("utf-8") == "top_3"
-    assert raft_node_4._log[3].entry.value == 9
-    assert raft_node_4._commit_index == 4
+    assert raft_node_4._log[3].entry.value == 10
+    assert raft_node_4._commit_index == 3
 
-    assert len(raft_node_3._log) == 1 + 4
+    assert len(raft_node_3._log) == 1 + 3
     assert raft_node_3._log[0].term == 0
     assert raft_node_3._log[0].entry.name.value.tobytes().decode("utf-8") == ""  # index zero entry is empty
     assert raft_node_3._log[0].entry.value == 0
@@ -1033,10 +1026,10 @@ async def _unittest_raft_leader_changes() -> None:
     assert raft_node_3._log[2].term == 1
     assert raft_node_3._log[2].entry.name.value.tobytes().decode("utf-8") == "top_2"
     assert raft_node_3._log[2].entry.value == 8
-    assert raft_node_3._log[3].term == 1
+    assert raft_node_3._log[3].term == 2
     assert raft_node_3._log[3].entry.name.value.tobytes().decode("utf-8") == "top_3"
-    assert raft_node_3._log[3].entry.value == 9
-    assert raft_node_3._commit_index == 4
+    assert raft_node_3._log[3].entry.value == 10
+    assert raft_node_3._commit_index == 3
 
     raft_node_2.close()
     raft_node_3.close()

--- a/tests/raft_node.py
+++ b/tests/raft_node.py
@@ -769,7 +769,7 @@ async def _unittest_raft_node_append_entries_rpc() -> None:
     response = await raft_node._serve_append_entries(request, metadata)
     assert response.success == False
 
-    assert raft_node._term == 10
+    assert raft_node._term == 11
     assert raft_node._voted_for == 42
 
     assert len(raft_node._log) == 1 + 4


### PR DESCRIPTION
Now, the `_server_append_entries` method sends entries. If adding an element fails, it decrements the value of `self._next_index[remote_node_index]`. If adding the element succeeds, it increments this value.
This way we avoid the case where the new leader rewrites all the logs anew, even if they already exist on the follower.

Additionally, the `_serve_append_entries` method was modified: new if-conditions were added, and the element removal function was moved from the `_append_entries_processing` method to this one.